### PR TITLE
Fix Andorid building errors and Disable multi-plane

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20,7 +20,7 @@ cc_library_static {
 
     srcs: ["utils/Worker.cpp"],
 
-    include_dirs: ["external/drm_hwcomposer"],
+    include_dirs: ["vendor/intel/external/drm-hwcomposer"],
 
     cflags: [
         "-Wall",
@@ -48,7 +48,7 @@ cc_defaults {
         "libutils",
     ],
 
-    include_dirs: ["external/drm_hwcomposer"],
+    include_dirs: ["vendor/intel/external/drm-hwcomposer"],
 
     static_libs: ["libdrmhwc_utils"],
 
@@ -61,6 +61,7 @@ cc_defaults {
         "-DHWC2_INCLUDE_STRINGIFICATION",
         "-DHWC2_USE_CPP11",
         "-std=c++17",
+        "-DUSE_IMAPPER4_METADATA_API",
     ],
 
     product_variables: {

--- a/drm/DrmConnector.h
+++ b/drm/DrmConnector.h
@@ -16,10 +16,10 @@
 
 #ifndef ANDROID_DRM_CONNECTOR_H_
 #define ANDROID_DRM_CONNECTOR_H_
-
+#include <cstdint>
 #include <xf86drmMode.h>
 
-#include <cstdint>
+
 #include <string>
 #include <vector>
 

--- a/drm/DrmCrtc.h
+++ b/drm/DrmCrtc.h
@@ -16,10 +16,10 @@
 
 #ifndef ANDROID_DRM_CRTC_H_
 #define ANDROID_DRM_CRTC_H_
-
+#include <cstdint>
 #include <xf86drmMode.h>
 
-#include <cstdint>
+
 
 #include "DrmDisplayPipeline.h"
 #include "DrmMode.h"

--- a/drm/DrmDevice.cpp
+++ b/drm/DrmDevice.cpp
@@ -147,7 +147,9 @@ auto DrmDevice::Init(const char *path) -> int {
     auto plane = DrmPlane::CreateInstance(*this, plane_res->planes[i]);
 
     if (plane) {
-      planes_.emplace_back(std::move(plane));
+      //planes_.emplace_back(std::move(plane));
+      if (plane->GetType() == DRM_PLANE_TYPE_PRIMARY)
+        planes_.emplace_back(std::move(plane));
     }
   }
 

--- a/drm/DrmEncoder.h
+++ b/drm/DrmEncoder.h
@@ -16,10 +16,10 @@
 
 #ifndef ANDROID_DRM_ENCODER_H_
 #define ANDROID_DRM_ENCODER_H_
-
+#include <cstdint>
 #include <xf86drmMode.h>
 
-#include <cstdint>
+
 #include <set>
 #include <vector>
 

--- a/drm/DrmMode.h
+++ b/drm/DrmMode.h
@@ -16,10 +16,9 @@
 
 #ifndef ANDROID_DRM_MODE_H_
 #define ANDROID_DRM_MODE_H_
-
+#include <cstdint>
 #include <xf86drmMode.h>
 
-#include <cstdint>
 #include <cstdio>
 #include <string>
 

--- a/drm/DrmPlane.h
+++ b/drm/DrmPlane.h
@@ -16,10 +16,9 @@
 
 #ifndef ANDROID_DRM_PLANE_H_
 #define ANDROID_DRM_PLANE_H_
-
+#include <cstdint>
 #include <xf86drmMode.h>
 
-#include <cstdint>
 #include <vector>
 
 #include "DrmCrtc.h"

--- a/drm/DrmProperty.h
+++ b/drm/DrmProperty.h
@@ -16,10 +16,9 @@
 
 #ifndef ANDROID_DRM_PROPERTY_H_
 #define ANDROID_DRM_PROPERTY_H_
-
+#include <cstdint>
 #include <xf86drmMode.h>
 
-#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/tests/Android.bp
+++ b/tests/Android.bp
@@ -28,7 +28,7 @@ cc_test {
     header_libs: ["libhardware_headers"],
     static_libs: ["libdrmhwc_utils"],
     shared_libs: ["hwcomposer.drm"],
-    include_dirs: ["external/drm_hwcomposer"],
+    include_dirs: ["vendor/intel/external/drm-hwcomposer"],
 }
 
 // Tool for listening and dumping uevents
@@ -41,6 +41,6 @@ cc_test {
     header_libs: ["libhardware_headers"],
     shared_libs: ["liblog"],
     include_dirs: [
-        "external/drm_hwcomposer",
+        "vendor/intel/external/drm-hwcomposer",
     ],
 }


### PR DESCRIPTION
i)Change makefiles' include path appropriately.

ii)Fix display flicker issue by enable only primary plane.

Change-Id: Ie1fe8d0f191dc76fe73ad90c0985b6002411eb86
Tracked-On: No
Signed-off-by: Liu, Yuanzhe <yuanzhe.liu@intel.com>