### PR TITLE
Revert "drm_hwcomposer: Implement BI and FB caching"

### DIFF
--- a/hwc2_device/HwcDisplay.cpp
+++ b/hwc2_device/HwcDisplay.cpp
@@ -602,7 +602,6 @@ HWC2::Error HwcDisplay::SetClientTarget(buffer_handle_t target,
    * https://cs.android.com/android/platform/superproject/+/master:hardware/interfaces/graphics/composer/2.1/utils/hal/include/composer-hal/2.1/ComposerClient.h;l=350;drc=944b68180b008456ed2eb4d4d329e33b19bd5166
    */
   if (target == nullptr) {
-    client_layer_.SwChainClearCache();
     return HWC2::Error::None;
   }
 

--- a/hwc2_device/HwcLayer.cpp
+++ b/hwc2_device/HwcLayer.cpp
@@ -174,11 +174,6 @@ void HwcLayer::ImportFb() {
 
   layer_data_.fb = {};
 
-  auto unique_id = BufferInfoGetter::GetInstance()->GetUniqueId(buffer_handle_);
-  if (unique_id && SwChainGetBufferFromCache(*unique_id)) {
-    return;
-  }
-
   layer_data_.bi = BufferInfoGetter::GetInstance()->GetBoInfo(buffer_handle_);
   if (!layer_data_.bi) {
     ALOGW("Unable to get buffer information (0x%p)", buffer_handle_);
@@ -195,10 +190,6 @@ void HwcLayer::ImportFb() {
           buffer_handle_);
     fb_import_failed_ = true;
     return;
-  }
-
-  if (unique_id) {
-    SwChainAddCurrentBuffer(*unique_id);
   }
 }
 
@@ -218,77 +209,6 @@ void HwcLayer::PopulateLayerData(bool test) {
   if (!test) {
     layer_data_.acquire_fence = std::move(acquire_fence_);
   }
-}
-
-/* SwapChain Cache */
-
-bool HwcLayer::SwChainGetBufferFromCache(BufferUniqueId unique_id) {
-  if (swchain_lookup_table_.count(unique_id) == 0) {
-    return false;
-  }
-
-  int seq = swchain_lookup_table_[unique_id];
-
-  if (swchain_cache_.count(seq) == 0) {
-    return false;
-  }
-
-  auto& el = swchain_cache_[seq];
-  if (!el.bi) {
-    return false;
-  }
-
-  layer_data_.bi = el.bi;
-  layer_data_.fb = el.fb;
-
-  return true;
-}
-
-void HwcLayer::SwChainReassemble(BufferUniqueId unique_id) {
-  if (swchain_lookup_table_.count(unique_id) != 0) {
-    if (swchain_lookup_table_[unique_id] ==
-        int(swchain_lookup_table_.size()) - 1) {
-      /* Skip same buffer */
-      return;
-    }
-    if (swchain_lookup_table_[unique_id] == 0) {
-      swchain_reassembled_ = true;
-      return;
-    }
-    /* Tracking error */
-    SwChainClearCache();
-    return;
-  }
-
-  swchain_lookup_table_[unique_id] = int(swchain_lookup_table_.size());
-}
-
-void HwcLayer::SwChainAddCurrentBuffer(BufferUniqueId unique_id) {
-  if (!swchain_reassembled_) {
-    SwChainReassemble(unique_id);
-  }
-
-  if (swchain_reassembled_) {
-    if (swchain_lookup_table_.count(unique_id) == 0) {
-      SwChainClearCache();
-      return;
-    }
-
-    int seq = swchain_lookup_table_[unique_id];
-
-    if (swchain_cache_.count(seq) == 0) {
-      swchain_cache_[seq] = {};
-    }
-
-    swchain_cache_[seq].bi = layer_data_.bi;
-    swchain_cache_[seq].fb = layer_data_.fb;
-  }
-}
-
-void HwcLayer::SwChainClearCache() {
-  swchain_cache_.clear();
-  swchain_lookup_table_.clear();
-  swchain_reassembled_ = false;
 }
 
 }  // namespace android

--- a/hwc2_device/HwcLayer.h
+++ b/hwc2_device/HwcLayer.h
@@ -19,7 +19,6 @@
 
 #include <hardware/hwcomposer2.h>
 
-#include "bufferinfo/BufferInfoGetter.h"
 #include "compositor/LayerData.h"
 
 namespace android {
@@ -119,24 +118,6 @@ class HwcLayer {
   void ImportFb();
   bool bi_get_failed_{};
   bool fb_import_failed_{};
-
-  /* SwapChain Cache */
- public:
-  void SwChainClearCache();
-
- private:
-  struct SwapChainElement {
-    std::optional<BufferInfo> bi;
-    std::shared_ptr<DrmFbIdHandle> fb;
-  };
-
-  bool SwChainGetBufferFromCache(BufferUniqueId unique_id);
-  void SwChainReassemble(BufferUniqueId unique_id);
-  void SwChainAddCurrentBuffer(BufferUniqueId unique_id);
-
-  std::map<int /*seq_no*/, SwapChainElement> swchain_cache_;
-  std::map<BufferUniqueId, int /*seq_no*/> swchain_lookup_table_;
-  bool swchain_reassembled_{};
 };
 
 }  // namespace android


### PR DESCRIPTION
Revert a32f907c9dddc4d064b0bff7c68dddb910ad3812 to
fix SR-IOV mouse click causing kernel panic issue.

Change-Id: I4bce7389870b026bde8196d0418ddd3b1226788d
Tracked-On: OAM-102863
Signed-Off-By: Liu, Yuanzhe <yuanzhe.liu@intel.com>