### PR TITLE
Need enable non-blocking atomic commit in drm-hwc

### DIFF
--- a/drm/DrmAtomicStateManager.cpp
+++ b/drm/DrmAtomicStateManager.cpp
@@ -153,7 +153,7 @@ auto DrmAtomicStateManager::CommitFrame(AtomicCommitArgs &args) -> int {
     CleanupPriorFrameResources();
   }
 
-  if (nonblock) {
+  if (nonblock && drm->GetName() == "i915") {
     flags |= DRM_MODE_ATOMIC_NONBLOCK;
   }
 


### PR DESCRIPTION
Previously when enable atomic commit, SRIOV has crash problem. When the problem happened, even the system is in panic. Then we have to revert the patch which enable atomic commit.

While for performance consideration, we need enable atomic commit. And hwc check if device name is i915, enable non-blocking commit.