### PR TITLE
Add hdr support

### DIFF
--- a/drm/DrmAtomicStateManager.h
+++ b/drm/DrmAtomicStateManager.h
@@ -30,6 +30,7 @@
 #include "drm/DrmPlane.h"
 #include "drm/ResourceManager.h"
 #include "drm/VSyncWorker.h"
+#include "utils/cta_hdr_defs.h"
 
 namespace android {
 
@@ -128,6 +129,7 @@ class DrmAtomicStateManager {
   UniqueFd last_present_fence_;
   int frames_staged_{};
   int frames_tracked_{};
+  bool hdr_mdata_set_ = false;
 };
 
 }  // namespace android

--- a/drm/DrmConnector.cpp
+++ b/drm/DrmConnector.cpp
@@ -24,6 +24,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <sstream>
+#include <math.h>
 
 #include "DrmDevice.h"
 #include "utils/log.h"
@@ -73,9 +74,12 @@ auto DrmConnector::CreateInstance(DrmDevice &dev, uint32_t connector_id,
       new DrmConnector(std::move(conn), &dev, index));
 
   if (!GetConnectorProperty(dev, *c, "DPMS", &c->dpms_property_) ||
-      !GetConnectorProperty(dev, *c, "CRTC_ID", &c->crtc_id_property_)) {
-    return {};
+      !GetConnectorProperty(dev, *c, "CRTC_ID", &c->crtc_id_property_) ||
+      (dev.IsHdrSupportedDevice() && !GetConnectorProperty(dev, *c, "HDR_OUTPUT_METADATA", &c->hdr_op_metadata_prop_))) {
+      return {};
   }
+
+  c->hdr_metadata_.valid = false;
 
   c->UpdateEdidProperty();
 
@@ -146,6 +150,11 @@ bool DrmConnector::IsWriteback() const {
 
 bool DrmConnector::IsValid() const {
   return IsInternal() || IsExternal() || IsWriteback();
+}
+
+bool DrmConnector::IsHdrSupportedDevice()
+{
+  return drm_->IsHdrSupportedDevice();
 }
 
 std::string DrmConnector::GetName() const {
@@ -285,6 +294,266 @@ int DrmConnector::UpdateModes() {
 
 void DrmConnector::SetActiveMode(DrmMode &mode) {
   active_mode_ = mode;
+}
+
+uint16_t DrmConnector::ColorPrimary(short val) {
+  short temp = val & 0x3FF;
+  short count = 1;
+  float result = 0;
+  uint16_t output;
+
+  /* Primary values in EDID are ecoded in 10 bit format, where every bit
+   * represents 2 pow negative bit position, ex 0.500 = 1/2 = 2 ^ -1 = (1 << 9)
+   */
+  while (temp) {
+    result += ((!!(temp & (1 << 9))) * pow(2, -count));
+    count++;
+    temp <<= 1;
+  }
+
+  /* Primaries are to represented in uint16 format, in power of 0.00002,
+   *     * max allowed value is 50,000 */
+  output = result * 50000;
+  if (output > 50000)
+    output = 50000;
+
+  return output;
+}
+
+void DrmConnector::GetHDRStaticMetadata(uint8_t *b, uint8_t length) {
+
+  if (length < 2) {
+    ALOGE("Invalid metadata input to static parser\n");
+    return;
+  }
+
+  display_hdrMd_ = (struct cta_edid_hdr_metadata_static *)malloc(
+      sizeof(struct cta_edid_hdr_metadata_static));
+  if (!display_hdrMd_) {
+    ALOGE("OOM while parsing static metadata\n");
+    return;
+  }
+  memset(display_hdrMd_, 0, sizeof(struct cta_edid_hdr_metadata_static));
+
+  display_hdrMd_->eotf = b[0] & 0x3F;
+  display_hdrMd_->metadata_type = b[1];
+
+  if (length > 2 && length < 6) {
+    display_hdrMd_->desired_max_ll = b[2];
+    display_hdrMd_->desired_max_fall = b[3];
+    display_hdrMd_->desired_min_ll = b[4];
+
+    if (!display_hdrMd_->desired_max_ll)
+      display_hdrMd_->desired_max_ll = 0xFF;
+  }
+  return;
+}
+
+#define HIGH_X(val) (val >> 6)
+#define HIGH_Y(val) ((val >> 4) & 0x3)
+#define LOW_X(val) ((val >> 2) & 0x3)
+#define LOW_Y(val) ((val >> 4) & 0x3)
+
+
+void DrmConnector::GetColorPrimaries( uint8_t *b, struct cta_display_color_primaries *p) {
+  uint8_t rxrygxgy_0_1;
+  uint8_t bxbywxwy_0_1;
+  uint8_t count = 0x19; /* base of chromaticity block values */
+  uint16_t val;
+
+  if (!b || !p)
+    return;
+
+  rxrygxgy_0_1 = b[count++];
+  bxbywxwy_0_1 = b[count++];
+
+  val = (b[count++] << 2) | HIGH_X(rxrygxgy_0_1);
+  p->display_primary_r_x = ColorPrimary(val);
+
+  val = (b[count++] << 2) | HIGH_Y(rxrygxgy_0_1);
+  p->display_primary_r_y = ColorPrimary(val);
+
+  val = (b[count++] << 2) | LOW_X(rxrygxgy_0_1);
+  p->display_primary_g_x = ColorPrimary(val);
+
+  val = (b[count++] << 2) | LOW_Y(rxrygxgy_0_1);
+  p->display_primary_g_y = ColorPrimary(val);
+
+  val = (b[count++] << 2) | HIGH_X(bxbywxwy_0_1);
+  p->display_primary_b_x = ColorPrimary(val);
+
+  val = (b[count++] << 2) | HIGH_Y(bxbywxwy_0_1);
+  p->display_primary_b_y = ColorPrimary(val);
+
+  val = (b[count++] << 2) | LOW_X(bxbywxwy_0_1);
+  p->white_point_x = ColorPrimary(val);
+
+  val = (b[count++] << 2) | LOW_X(bxbywxwy_0_1);
+  p->white_point_y = ColorPrimary(val);
+}
+
+void DrmConnector::ParseCTAFromExtensionBlock(uint8_t *edid) {
+  int current_block;
+  uint8_t *cta_ext_blk;
+  uint8_t dblen;
+  uint8_t d;
+  uint8_t *cta_db_start;
+  uint8_t *cta_db_end;
+  uint8_t *dbptr;
+  uint8_t tag;
+
+  int num_blocks = edid[126];
+  if (!num_blocks) {
+    return;
+  }
+
+  for (current_block = 1; current_block <= num_blocks; current_block++) {
+    cta_ext_blk = edid + 128 * current_block;
+    if (cta_ext_blk[0] != CTA_EXTENSION_TAG)
+      continue;
+    d = cta_ext_blk[2];
+    cta_db_start = cta_ext_blk + 4;
+    cta_db_end = cta_ext_blk + d - 1;
+    for (dbptr = cta_db_start; dbptr < cta_db_end; dbptr++) {
+      tag = dbptr[0] >> 0x05;
+      dblen = dbptr[0] & 0x1F;
+
+      // Check if the extension has an extended block
+      if (tag == CTA_EXTENDED_TAG_CODE) {
+        switch (dbptr[1]) {
+          case CTA_COLORIMETRY_CODE:
+            ALOGE(" Colorimetry Data block\n");
+            break;
+          case CTA_HDR_STATIC_METADATA:
+            ALOGE(" HDR STATICMETADATA block\n");
+            DrmConnector::GetHDRStaticMetadata(dbptr + 2, dblen - 1);
+            break;
+          default:
+            ALOGE(" Unknown tag/Parsing option\n");
+        }
+        DrmConnector::GetColorPrimaries(dbptr + 2, &primaries_);
+      }
+    }
+  }
+}
+
+bool DrmConnector::GetHdrCapabilities(uint32_t *outNumTypes, int32_t *outTypes,
+                                    float *outMaxLuminance,
+                                    float *outMaxAverageLuminance,
+                                    float *outMinLuminance) {
+  if (NULL == outNumTypes) {
+    ALOGE("outNumTypes couldn't be NULL!");
+    return false;
+  }
+
+  if (NULL == outTypes) {
+    ALOGE("outTypes couldn't be NULL!");
+    //TODO: clarify SF's logic here
+    //kindly skip this check now and return nothing if it's NULL
+    //return false;
+  }
+
+  if (NULL == outMaxLuminance) {
+    ALOGE("outMaxLuminance couldn't be NULL!");
+    return false;
+  }
+
+  if (NULL == outMaxAverageLuminance) {
+    ALOGE("outMaxAverageLuminance couldn't be NULL!");
+    return false;
+  }
+
+  if (NULL == outMinLuminance) {
+    ALOGE("outMinLuminance couldn't be NULL!");
+    return false;
+  }
+
+  if (display_hdrMd_) {
+    // HDR meta block bit 3 of byte 3: STPTE ST 2084
+    if (display_hdrMd_->eotf & 0x04) {
+      if(outTypes)
+        *(outTypes + *outNumTypes) = (uint32_t)EOTF_ST2084;
+      (*outNumTypes)+=1;
+    }
+    // HDR meta block bit 4 of byte 3: HLG
+    if (display_hdrMd_->eotf & 0x08) {
+      if(outTypes)
+        *(outTypes + *outNumTypes) = (uint32_t)EOTF_HLG;
+      (*outNumTypes)+=1;
+    }
+    double outmaxluminance, outmaxaverageluminance, outminluminance;
+    // Luminance value = 50 * POW(2, coded value / 32)
+    // Desired Content Min Luminance = Desired Content Max Luminance * POW(2,
+    // coded value/255) / 100
+    outmaxluminance = pow(2.0, display_hdrMd_->desired_max_ll / 32.0) * 50.0;
+    *outMaxLuminance = float(outmaxluminance);
+    outmaxaverageluminance =
+        pow(2.0, display_hdrMd_->desired_max_fall / 32.0) * 50.0;
+    *outMaxAverageLuminance = float(outmaxaverageluminance);
+    outminluminance = display_hdrMd_->desired_max_ll *
+                      pow(2.0, display_hdrMd_->desired_min_ll / 255.0) / 100;
+    *outMinLuminance = float(outminluminance);
+
+    int ret = GetConnectorProperty(*drm_, *this, "HDR_OUTPUT_METADATA", &hdr_op_metadata_prop_);
+    if (ret) {
+      ALOGE("Could not get HDR_OUTPUT_METADATA property\n");
+      //return ret;
+    }
+  }
+
+  return true;
+}
+
+bool DrmConnector::GetRenderIntents(uint32_t *outNumIntents, int32_t *outIntents) {
+  // If HDR is supported, adds HDR render intents accordingly.
+  if (display_hdrMd_ && display_hdrMd_->eotf & 0x0C) {
+    *(outIntents + *outNumIntents) = HAL_RENDER_INTENT_TONE_MAP_COLORIMETRIC;
+    *(outNumIntents)+=1;
+    *(outIntents + *outNumIntents) = HAL_RENDER_INTENT_TONE_MAP_ENHANCE;
+    *(outNumIntents)+=1;
+  }
+   return true;
+}
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MIN_IF_NT_ZERO(c, d) (c ? MIN(c, d) : d)
+void DrmConnector::PrepareHdrMetadata(hdr_md *layer_hdr_metadata,
+                                    struct  hdr_output_metadata *final_hdr_metadata) {
+
+  struct hdr_metadata_static *l_md = &layer_hdr_metadata->static_metadata;
+  struct hdr_metadata_infoframe *out_static_md =
+      &final_hdr_metadata->hdmi_metadata_type1;
+
+  out_static_md->max_cll = l_md->max_cll;
+  out_static_md->max_fall = l_md->max_fall;
+  out_static_md->max_display_mastering_luminance = l_md->max_luminance;
+  out_static_md->min_display_mastering_luminance = l_md->min_luminance;
+  out_static_md->display_primaries[0].x =
+      MIN_IF_NT_ZERO(ColorPrimary(l_md->primaries.r.x),
+                     primaries_.display_primary_r_x);
+  out_static_md->display_primaries[0].y =
+      MIN_IF_NT_ZERO(ColorPrimary(l_md->primaries.r.y),
+                     primaries_.display_primary_r_y);
+  out_static_md->display_primaries[1].x =
+      MIN_IF_NT_ZERO(ColorPrimary(l_md->primaries.g.x),
+                     primaries_.display_primary_g_x);
+  out_static_md->display_primaries[1].y =
+      MIN_IF_NT_ZERO(ColorPrimary(l_md->primaries.g.y),
+                     primaries_.display_primary_g_y);
+  out_static_md->display_primaries[2].x =
+      MIN_IF_NT_ZERO(ColorPrimary(l_md->primaries.g.x),
+                     primaries_.display_primary_b_x);
+  out_static_md->display_primaries[2].y =
+      MIN_IF_NT_ZERO(ColorPrimary(l_md->primaries.g.y),
+                     primaries_.display_primary_b_y);
+  out_static_md->white_point.x =
+      MIN_IF_NT_ZERO(ColorPrimary(l_md->primaries.white_point.x),
+                     primaries_.white_point_x);
+  out_static_md->white_point.y =
+      MIN_IF_NT_ZERO(ColorPrimary(l_md->primaries.white_point.y),
+                     primaries_.white_point_y);
+  out_static_md->eotf = CTA_EOTF_HDR_ST2084;
+  out_static_md->metadata_type = 1;
 }
 
 const DrmProperty &DrmConnector::link_status_property() const {

--- a/drm/DrmConnector.h
+++ b/drm/DrmConnector.h
@@ -23,10 +23,14 @@
 #include <string>
 #include <vector>
 
+#include <drm/drm_mode.h>
+
 #include "DrmEncoder.h"
 #include "DrmMode.h"
 #include "DrmProperty.h"
 #include "DrmUnique.h"
+#include "utils/hdr_metadata_defs.h"
+#include "utils/cta_hdr_defs.h"
 
 namespace android {
 
@@ -102,9 +106,20 @@ class DrmConnector : public PipelineBindable<DrmConnector> {
     return edid_property_;
   }
 
+  auto &GetHdrOpMetadataProp() const {
+    return hdr_op_metadata_prop_;
+  }
+
+  auto &GetHdrMatedata() {
+    return hdr_metadata_;
+  }
+
+
   auto IsConnected() const {
     return connector_->connection == DRM_MODE_CONNECTED;
   }
+
+  bool IsHdrSupportedDevice();
 
   auto GetMmWidth() const {
     return connector_->mmWidth;
@@ -113,6 +128,19 @@ class DrmConnector : public PipelineBindable<DrmConnector> {
   auto GetMmHeight() const {
     return connector_->mmHeight;
   };
+
+  void GetHDRStaticMetadata(uint8_t *b, uint8_t length);
+  uint16_t ColorPrimary(short val);
+  void GetColorPrimaries(uint8_t *b, struct cta_display_color_primaries *primaries);
+  void ParseCTAFromExtensionBlock(uint8_t *edid);
+  bool GetHdrCapabilities(uint32_t *outNumTypes, int32_t *outTypes,
+                                    float *outMaxLuminance,
+                                    float *outMaxAverageLuminance,
+                                    float *outMinLuminance);
+  bool GetRenderIntents( uint32_t *outNumIntents, int32_t *outIntents);
+
+  void PrepareHdrMetadata(hdr_md *layer_hdr_metadata,
+                          struct hdr_output_metadata *final_hdr_metadata);
 
   const DrmProperty &link_status_property() const;
  private:
@@ -138,6 +166,16 @@ class DrmConnector : public PipelineBindable<DrmConnector> {
   DrmProperty link_status_property_;
 
   uint32_t preferred_mode_id_{};
+  //hdr_output_metadata property
+  DrmProperty hdr_op_metadata_prop_;
+
+  /* Display's color primaries */
+  struct cta_display_color_primaries primaries_;
+
+  /* Display's static HDR metadata */
+  struct cta_edid_hdr_metadata_static *display_hdrMd_;
+
+  hdr_md hdr_metadata_;
 };
 }  // namespace android
 

--- a/drm/DrmDevice.cpp
+++ b/drm/DrmDevice.cpp
@@ -249,6 +249,28 @@ std::string DrmDevice::GetName() const {
   return name;
 }
 
+bool DrmDevice::IsHdrSupportedDevice() {
+  if (!hdr_device_checked_) {
+    hdr_device_checked_ = true;
+    auto *ver = drmGetVersion(GetFd());
+    if (ver == nullptr) {
+      ALOGW("Failed to get drm version for fd=%d", GetFd());
+      is_hdr_supported_ = false;;
+    } else {
+      std::string name(ver->name);
+      ALOGD("drm device name is : %s\n", name.c_str());
+      if (name == "i915") {
+        is_hdr_supported_ = true;
+      } else {
+        is_hdr_supported_ = false;
+      }
+    }
+    drmFreeVersion(ver);
+  }
+
+  return is_hdr_supported_;
+}
+
 auto DrmDevice::IsKMSDev(const char *path) -> bool {
   auto fd = UniqueFd(open(path, O_RDWR | O_CLOEXEC));
   if (!fd) {

--- a/drm/DrmDevice.h
+++ b/drm/DrmDevice.h
@@ -65,6 +65,8 @@ class DrmDevice {
 
   std::string GetName() const;
 
+  bool IsHdrSupportedDevice();
+
   auto RegisterUserPropertyBlob(void *data, size_t length) const
       -> DrmModeUserPropertyBlobUnique;
 
@@ -110,6 +112,9 @@ class DrmDevice {
 
   UniqueFd fd_;
   uint32_t mode_id_ = 0;
+
+  bool is_hdr_supported_ = false;
+  bool hdr_device_checked_ = false;
 
   std::vector<std::unique_ptr<DrmConnector>> connectors_;
   std::vector<std::unique_ptr<DrmConnector>> writeback_connectors_;

--- a/hwc2_device/HwcDisplay.cpp
+++ b/hwc2_device/HwcDisplay.cpp
@@ -259,12 +259,43 @@ HWC2::Error HwcDisplay::GetClientTargetSupport(uint32_t width, uint32_t height,
 }
 
 HWC2::Error HwcDisplay::GetColorModes(uint32_t *num_modes, int32_t *modes) {
-  if (!modes)
-    *num_modes = 1;
 
-  if (modes)
-    *modes = HAL_COLOR_MODE_NATIVE;
+  DrmConnector *conn = pipeline_->connector->Get();
+  ALOGD("%s, num_modes:%p, modes:%p, conn:%p", __FUNCTION__, num_modes, modes, conn);
+  if (conn && !conn->IsHdrSupportedDevice()) {
+     ALOGD("%s HDR mode is not supported!", __FUNCTION__);
+     if (!modes) {
+       if (num_modes) {
+         *num_modes = 1;
+       } else {
+         ALOGD("%s:%d num_modes is NULL!", __FUNCTION__, __LINE__);
+       }
+     }
 
+     if (modes)
+       *modes = HAL_COLOR_MODE_NATIVE;
+  }
+  else {
+    ALOGD("%s HDR mode is supported.", __FUNCTION__);
+    if (!modes) {
+      if (num_modes) {
+        *num_modes = current_color_mode_.size();
+        ALOGD("Set the num_modes to: %u!", (uint32_t) current_color_mode_.size());
+      } else {
+        ALOGD("%s:%d num_modes is NULL!", __FUNCTION__, __LINE__);
+      }
+    } else {
+      if (num_modes) {
+        *num_modes = current_color_mode_.size();
+        ALOGD("Set the num_modes to:%u", (uint32_t) current_color_mode_.size());
+      } else {
+        ALOGD("%s:%d num_modes is null!", __FUNCTION__, __LINE__);
+      }
+      for (int i = 0; i < current_color_mode_.size(); i++) {
+        *(modes + i) = current_color_mode_[i];
+      }
+    }
+  }
   return HWC2::Error::None;
 }
 
@@ -381,12 +412,48 @@ HWC2::Error HwcDisplay::GetDozeSupport(int32_t *support) {
   return HWC2::Error::None;
 }
 
+HWC2::Error HwcDisplay::GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys) {
+  if (NULL == outNumKeys && NULL == outKeys) {
+    return HWC2::Error::BadParameter;
+  }
+
+  *outNumKeys = KEY_NUM_PER_FRAME_METADATA_KEYS;
+  if (NULL == outKeys)
+    return HWC2::Error::None;
+
+  for (int i = 0; i < KEY_NUM_PER_FRAME_METADATA_KEYS; i++) {
+    *(outKeys + i) = i;
+  }
+
+  return HWC2::Error::None;
+}
+
 HWC2::Error HwcDisplay::GetHdrCapabilities(uint32_t *num_types,
-                                           int32_t * /*types*/,
-                                           float * /*max_luminance*/,
-                                           float * /*max_average_luminance*/,
-                                           float * /*min_luminance*/) {
+                                           int32_t * types,
+                                           float * max_luminance,
+                                           float * max_average_luminance,
+                                           float * min_luminance) {
   *num_types = 0;
+  DrmConnector *conn = pipeline_->connector->Get();
+
+  if (conn && conn->IsHdrSupportedDevice()) {
+    auto blob = conn->GetEdidBlob();
+    if (blob) {
+      ALOGE("Failed to get edid property value.");
+      return HWC2::Error::Unsupported;
+    }
+
+    conn->ParseCTAFromExtensionBlock((uint8_t*)blob->data);
+
+    if (conn->GetHdrCapabilities(num_types, types, max_luminance,
+                                   max_average_luminance, min_luminance)) {
+      return HWC2::Error::None;
+    } else {
+      return HWC2::Error::Unsupported;
+    }
+  }
+
+
   return HWC2::Error::None;
 }
 
@@ -882,16 +949,43 @@ HWC2::Error HwcDisplay::SetDisplayBrightness(float /* brightness */) {
 HWC2::Error HwcDisplay::GetRenderIntents(
     int32_t mode, uint32_t *outNumIntents,
     int32_t * /*android_render_intent_v1_1_t*/ outIntents) {
-  if (mode != HAL_COLOR_MODE_NATIVE) {
+
+  if (NULL == outNumIntents && NULL == outIntents) {
+    ALOGE("Null pointer error, outNumIntents: %p, outIntents: %p",
+          outNumIntents, outIntents);
     return HWC2::Error::BadParameter;
   }
 
-  if (outIntents == nullptr) {
+  DrmConnector *conn = pipeline_->connector->Get();
+
+  if (conn && !conn->IsHdrSupportedDevice()) {
+    if (mode != HAL_COLOR_MODE_NATIVE) {
+      return HWC2::Error::BadParameter;
+    }
+
+    if (outIntents == nullptr) {
+      *outNumIntents = 1;
+      return HWC2::Error::None;
+    }
     *outNumIntents = 1;
-    return HWC2::Error::None;
+    outIntents[0] = HAL_RENDER_INTENT_COLORIMETRIC;
+  } else {
+    // Add the SDR render intents by default.
+    if (NULL == outIntents) {
+       *outNumIntents = 2;
+      return HWC2::Error::None;
+    }
+
+    *(outIntents) = HAL_RENDER_INTENT_COLORIMETRIC;
+    *(outIntents + 1) = HAL_RENDER_INTENT_ENHANCE;
+    if (mode > HAL_COLOR_MODE_DISPLAY_P3) {
+      if (conn->GetRenderIntents(outNumIntents, outIntents))
+        return HWC2::Error::None;
+      else
+        return HWC2::Error::BadParameter;
+    }
   }
-  *outNumIntents = 1;
-  outIntents[0] = HAL_RENDER_INTENT_COLORIMETRIC;
+
   return HWC2::Error::None;
 }
 

--- a/hwc2_device/HwcDisplay.h
+++ b/hwc2_device/HwcDisplay.h
@@ -100,6 +100,7 @@ class HwcDisplay {
   HWC2::Error GetDisplayVsyncPeriod(uint32_t *outVsyncPeriod);
 
   HWC2::Error GetDozeSupport(int32_t *support);
+  HWC2::Error GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys);
   HWC2::Error GetHdrCapabilities(uint32_t *num_types, int32_t *types,
                                  float *max_luminance,
                                  float *max_average_luminance,
@@ -223,6 +224,7 @@ class HwcDisplay {
   std::map<hwc2_layer_t, HwcLayer> layers_;
   HwcLayer client_layer_;
   int32_t color_mode_{};
+  std::vector<int32_t> current_color_mode_ = {HAL_COLOR_MODE_NATIVE, HAL_COLOR_MODE_BT2020, HAL_COLOR_MODE_BT2100_PQ, HAL_COLOR_MODE_BT2100_HLG, /*HAL_COLOR_MODE_DISPLAY_BT2020*/};
   std::array<float, MATRIX_SIZE> color_transform_matrix_{};
   android_color_transform_t color_transform_hint_;
 

--- a/hwc2_device/HwcLayer.h
+++ b/hwc2_device/HwcLayer.h
@@ -77,6 +77,9 @@ class HwcLayer {
   HWC2::Error SetLayerTransform(int32_t transform);
   HWC2::Error SetLayerVisibleRegion(hwc_region_t visible);
   HWC2::Error SetLayerZOrder(uint32_t order);
+  HWC2::Error SetLayerPerFrameMetadata(uint32_t numElements,
+                                     const int32_t *keys,
+                                     const float *metadata);
 
  private:
   // sf_type_ stores the initial type given to us by surfaceflinger,

--- a/hwc2_device/hwc2_device.cpp
+++ b/hwc2_device/hwc2_device.cpp
@@ -197,6 +197,11 @@ static hwc2_function_pointer_t HookDevGetFunction(struct hwc2_device * /*dev*/,
       return ToHook<HWC2_PFN_GET_DOZE_SUPPORT>(
           DisplayHook<decltype(&HwcDisplay::GetDozeSupport),
                       &HwcDisplay::GetDozeSupport, int32_t *>);
+    case HWC2::FunctionDescriptor::GetPerFrameMetadataKeys:
+      return ToHook<HWC2_PFN_GET_PER_FRAME_METADATA_KEYS>(
+          DisplayHook<decltype(&HwcDisplay::GetPerFrameMetadataKeys),
+                      &HwcDisplay::GetPerFrameMetadataKeys, uint32_t *,
+                      int32_t *>);
     case HWC2::FunctionDescriptor::GetHdrCapabilities:
       return ToHook<HWC2_PFN_GET_HDR_CAPABILITIES>(
           DisplayHook<decltype(&HwcDisplay::GetHdrCapabilities),
@@ -363,6 +368,11 @@ static hwc2_function_pointer_t HookDevGetFunction(struct hwc2_device * /*dev*/,
       return ToHook<HWC2_PFN_SET_LAYER_Z_ORDER>(
           LayerHook<decltype(&HwcLayer::SetLayerZOrder),
                     &HwcLayer::SetLayerZOrder, uint32_t>);
+    case HWC2::FunctionDescriptor::SetLayerPerFrameMetadata:
+      return ToHook<HWC2_PFN_SET_LAYER_PER_FRAME_METADATA>(
+          LayerHook<decltype(&HwcLayer::SetLayerPerFrameMetadata),
+                    &HwcLayer::SetLayerPerFrameMetadata, uint32_t,
+                    const int32_t *, const float *>);
     case HWC2::FunctionDescriptor::Invalid:
     default:
       return nullptr;

--- a/utils/cta_hdr_defs.h
+++ b/utils/cta_hdr_defs.h
@@ -1,0 +1,63 @@
+/*
+Copyright (C) <2023> Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions
+and limitations under the License.
+
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef CTA_HDR_DEFS
+#define CTA_HDR_DEFS
+
+namespace android {
+
+#define CTA_EXTENSION_TAG 0x02
+#define CTA_COLORIMETRY_CODE 0x05
+#define CTA_HDR_STATIC_METADATA 0x06
+#define CTA_EXTENDED_TAG_CODE 0x07
+
+/* CTA-861-G: HDR Metadata names and types */
+
+enum cta_hdr_eotf_type {
+  CTA_EOTF_SDR_TRADITIONAL = 0,
+  CTA_EOTF_HDR_TRADITIONAL,
+  CTA_EOTF_HDR_ST2084,
+  CTA_EOTF_HLG_BT2100,
+  CTA_EOTF_MAX
+};
+
+/* Display's HDR Metadata */
+struct cta_edid_hdr_metadata_static {
+  uint8_t eotf;
+  uint8_t metadata_type;
+  uint8_t desired_max_ll;
+  uint8_t desired_max_fall;
+  uint8_t desired_min_ll;
+};
+
+/* Display's color primaries */
+struct cta_display_color_primaries {
+  uint16_t display_primary_r_x;
+  uint16_t display_primary_r_y;
+  uint16_t display_primary_g_x;
+  uint16_t display_primary_g_y;
+  uint16_t display_primary_b_x;
+  uint16_t display_primary_b_y;
+  uint16_t white_point_x;
+  uint16_t white_point_y;
+};
+
+}// namespace android
+
+#endif  // CTA_HDR_DEFS

--- a/utils/hdr_metadata_defs.h
+++ b/utils/hdr_metadata_defs.h
@@ -1,0 +1,91 @@
+/*
+Copyright (C) <2023> Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions
+and limitations under the License.
+
+
+SPDX-License-Identifier: Apache-2.0
+
+*/
+
+#ifndef PUBLIC_HDR_METADATA_DEFS_H
+#define PUBLIC_HDR_METADATA_DEFS_H
+
+#include <stdint.h>
+
+namespace android {
+/** A CIE 1931 color space*/
+struct cie_xy {
+  double x;
+  double y;
+};
+
+struct color_primaries {
+  struct cie_xy r;
+  struct cie_xy g;
+  struct cie_xy b;
+  struct cie_xy white_point;
+};
+
+struct colorspace {
+  struct color_primaries primaries;
+  const char *name;
+  const char *whitepoint_name;
+};
+
+enum hdr_metadata_type {
+  HDR_METADATA_TYPE1,
+  HDR_METADATA_TYPE2,
+};
+
+enum hdr_metadata_eotf {
+  EOTF_TRADITIONAL_GAMMA_SDR,
+  EOTF_TRADITIONAL_GAMMA_HDR,
+  EOTF_ST2084,
+  EOTF_HLG,
+};
+
+enum hdr_per_frame_metadata_keys {
+  KEY_DISPLAY_RED_PRIMARY_X,
+  KEY_DISPLAY_RED_PRIMARY_Y,
+  KEY_DISPLAY_GREEN_PRIMARY_X,
+  KEY_DISPLAY_GREEN_PRIMARY_Y,
+  KEY_DISPLAY_BLUE_PRIMARY_X,
+  KEY_DISPLAY_BLUE_PRIMARY_Y,
+  KEY_WHITE_POINT_X,
+  KEY_WHITE_POINT_Y,
+  KEY_MAX_LUMINANCE,
+  KEY_MIN_LUMINANCE,
+  KEY_MAX_CONTENT_LIGHT_LEVEL,
+  KEY_MAX_FRAME_AVERAGE_LIGHT_LEVEL,
+  KEY_NUM_PER_FRAME_METADATA_KEYS
+};
+
+struct hdr_metadata_static {
+  struct color_primaries primaries;
+  double max_luminance;
+  double min_luminance;
+  uint32_t max_cll;
+  uint32_t max_fall;
+  uint8_t eotf;
+};
+
+typedef struct {
+  bool valid = false;
+  enum hdr_metadata_type metadata_type;
+  struct hdr_metadata_static static_metadata;
+} hdr_md;
+
+}
+
+#endif


### PR DESCRIPTION
only tested on BT.2020.PQ hdr playback.

2022/10/12
Shuang: Rebased the patch to latest S mr0 branch.

2023/01/11
Shuang: Make the composer works in SRIOV environment with HDR patch
integrated.

2023/02/17
Shuang: Fixed the black screen flash during SDR video playback.

2023/02/24
Shuang: Soruce code revision based on review feedback from Fei:
use the hdr_output_metadata structure defined in drm/drm_mode.h

2023/03/02
Shuang: Source code revision based on reviews from Fei.

Change-Id: I81c74f0eeaf1007fbd0fc944a0d2709d787a9991
Tracked-On: OAM-105431
Signed-off-by: Liu,Yuanzhe <yuanzhe.liu@intel.com>