### PR TITLE
Fixed hotplug failed to work for 1to2 display convertor

### DIFF
--- a/drm/DrmDisplayPipeline.cpp
+++ b/drm/DrmDisplayPipeline.cpp
@@ -191,4 +191,27 @@ auto DrmDisplayPipeline::GetUsablePlanes()
   return planes;
 }
 
+auto DrmDisplayPipeline::AtomicDisablePipeline() -> int {
+  auto pset = MakeDrmModeAtomicReqUnique();
+  if (!pset) {
+    ALOGE("Failed to allocate property set");
+    return -EINVAL;
+  }
+
+  if (!connector->Get()->GetCrtcIdProperty().AtomicSet(*pset, 0) ||
+      !crtc->Get()->GetActiveProperty().AtomicSet(*pset,  0)||
+      !crtc->Get()->GetModeProperty().AtomicSet(*pset, 0)){
+        ALOGE("Failed to atomic disable connector & crtc property set");
+        return -EINVAL;
+  }
+
+  int err = drmModeAtomicCommit(device->GetFd(), pset.get(), DRM_MODE_ATOMIC_ALLOW_MODESET, device);
+  if (err != 0) {
+    ALOGE("Failed to commit pset ret=%d\n", err);
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
 }  // namespace android

--- a/drm/DrmDisplayPipeline.h
+++ b/drm/DrmDisplayPipeline.h
@@ -75,6 +75,8 @@ struct DrmDisplayPipeline {
   auto GetUsablePlanes()
       -> std::vector<std::shared_ptr<BindingOwner<DrmPlane>>>;
 
+  auto AtomicDisablePipeline() -> int;
+
   DrmDevice *device;
 
   std::shared_ptr<BindingOwner<DrmConnector>> connector;

--- a/drm/ResourceManager.cpp
+++ b/drm/ResourceManager.cpp
@@ -141,6 +141,7 @@ void ResourceManager::UpdateFrontendDisplays() {
         }
       } else {
         auto &pipeline = attached_pipelines_[conn];
+        pipeline->AtomicDisablePipeline();
         frontend_interface_->UnbindDisplay(pipeline.get());
         attached_pipelines_.erase(conn);
       }


### PR DESCRIPTION
set crtc active/modeid property to 0 and
set connector crtcid property to 0 when
HDMI is unpluged.

Tracked-On: OAM-104276
Signed-off-by: manxiaoliang <xiaoliangx.man@intel.com>