### PR TITLE
Enable multiple planes counter with property in HWC

### DIFF
--- a/drm/DrmDevice.cpp
+++ b/drm/DrmDevice.cpp
@@ -154,6 +154,12 @@ auto DrmDevice::Init(const char *path) -> int {
     return -ENOENT;
   }
 
+  constexpr char PLANES_MAX_NUM_STRING[] = "99";
+  planes_num_ = atoi(PLANES_MAX_NUM_STRING);
+  memset(property, 0 , PROPERTY_VALUE_MAX);
+  property_get("vendor.hwcomposer.planes.num", property, PLANES_MAX_NUM_STRING);
+  planes_num_ = atoi(property) <= 0 ? atoi(PLANES_MAX_NUM_STRING) : atoi(property);
+  ALOGD("The property 'vendor.hwcomposer.planes.num' value is %s", property);
   for (uint32_t i = 0; i < plane_res->count_planes; ++i) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     auto plane = DrmPlane::CreateInstance(*this, plane_res->planes[i]);

--- a/drm/DrmDevice.h
+++ b/drm/DrmDevice.h
@@ -128,6 +128,7 @@ class DrmDevice {
 public:
   bool preferred_mode_limit_;
   bool planes_enabling_;
+  int32_t planes_num_;
 };
 }  // namespace android
 

--- a/drm/DrmDisplayPipeline.cpp
+++ b/drm/DrmDisplayPipeline.cpp
@@ -176,9 +176,12 @@ auto DrmDisplayPipeline::GetUsablePlanes()
   static bool use_overlay_planes = ReadUseOverlayProperty();
 
   if (use_overlay_planes) {
+    int32_t planes_num = device->planes_num_ - 1;
     for (const auto &plane : device->GetPlanes()) {
       if (plane->IsCrtcSupported(*crtc->Get())) {
         if (plane->GetType() == DRM_PLANE_TYPE_OVERLAY) {
+          if (planes_num-- <= 0)
+            break;
           auto op = plane->BindPipeline(this, true);
           if (op) {
             planes.emplace_back(op);


### PR DESCRIPTION
Add propery 'vendor.hwcomposer.planes.num', can save to /vendor/build.prop. Only the property
'vendor.hwcomposer.planes.enabling' is set to '1', hwc will limit planes number up to
'vendor.hwcomposer.planes.num'.

Tracked-On: OAM-104385
Signed-off-by: Li, HaihongX <haihongx.li@intel.com>