### PR TITLE
drm/i915: enable multi refresh rate

### DIFF
--- a/drm/DrmConnector.h
+++ b/drm/DrmConnector.h
@@ -79,6 +79,7 @@ class DrmConnector : public PipelineBindable<DrmConnector> {
   std::string GetName() const;
 
   int UpdateModes();
+  void UpdateMultiRefreshRateModes(std::vector<DrmMode> &new_modes);
 
   auto &GetModes() const {
     return modes_;


### PR DESCRIPTION
drm/i915: enable multi refresh rate

add prop
vendor.hwcomposer.connector.multi_refresh_rate

if we set the prop to 1, we will get different modes
that the connector support in same resolution and in different refresh rate

Tracked-On: OAM-103154
Signed-off-by: Kanli Hu kanli.hu@intel.com