### PR TITLE
Video layer use device composition

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -48,7 +48,10 @@ cc_defaults {
         "libutils",
     ],
 
-    include_dirs: ["vendor/intel/external/drm-hwcomposer"],
+    include_dirs: [
+        "vendor/intel/external/drm-hwcomposer",
+        "hardware/intel/external/minigbm-intel/cros_gralloc",
+    ],
 
     static_libs: ["libdrmhwc_utils"],
 

--- a/compositor/DrmKmsPlan.cpp
+++ b/compositor/DrmKmsPlan.cpp
@@ -24,11 +24,12 @@
 
 namespace android {
 auto DrmKmsPlan::CreateDrmKmsPlan(DrmDisplayPipeline &pipe,
-                                  std::vector<LayerData> composition)
+                                  std::vector<LayerData> composition,
+                                  uint32_t video_layer_number)
     -> std::unique_ptr<DrmKmsPlan> {
   auto plan = std::make_unique<DrmKmsPlan>();
 
-  auto avail_planes = pipe.GetUsablePlanes();
+  auto avail_planes = pipe.GetUsablePlanes(video_layer_number);
 
   int z_pos = 0;
   for (auto &dhl : composition) {

--- a/compositor/DrmKmsPlan.h
+++ b/compositor/DrmKmsPlan.h
@@ -36,7 +36,8 @@ struct DrmKmsPlan {
   std::vector<LayerToPlaneJoining> plan;
 
   static auto CreateDrmKmsPlan(DrmDisplayPipeline &pipe,
-                               std::vector<LayerData> composition)
+                               std::vector<LayerData> composition,
+                               uint32_t video_layer_number)
       -> std::unique_ptr<DrmKmsPlan>;
 };
 

--- a/drm/DrmDevice.cpp
+++ b/drm/DrmDevice.cpp
@@ -163,13 +163,7 @@ auto DrmDevice::Init(const char *path) -> int {
   for (uint32_t i = 0; i < plane_res->count_planes; ++i) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     auto plane = DrmPlane::CreateInstance(*this, plane_res->planes[i]);
-
-    if (!planes_enabling_) {
-      if (plane->GetType() == DRM_PLANE_TYPE_PRIMARY)
-        planes_.emplace_back(std::move(plane));
-    } else {
-      planes_.emplace_back(std::move(plane));
-    }
+    planes_.emplace_back(std::move(plane));
   }
 
   return 0;

--- a/drm/DrmDisplayPipeline.cpp
+++ b/drm/DrmDisplayPipeline.cpp
@@ -168,15 +168,16 @@ static bool ReadUseOverlayProperty() {
   return strtol(use_overlay_planes_prop, nullptr, kStrtolBase) != 0;
 }
 
-auto DrmDisplayPipeline::GetUsablePlanes()
+auto DrmDisplayPipeline::GetUsablePlanes(uint32_t video_layer_number)
     -> std::vector<std::shared_ptr<BindingOwner<DrmPlane>>> {
   std::vector<std::shared_ptr<BindingOwner<DrmPlane>>> planes;
   planes.emplace_back(primary_plane);
 
   static bool use_overlay_planes = ReadUseOverlayProperty();
-
   if (use_overlay_planes) {
     int32_t planes_num = device->planes_num_ - 1;
+    if (!device->planes_enabling_)
+      planes_num = video_layer_number;
     for (const auto &plane : device->GetPlanes()) {
       if (plane->IsCrtcSupported(*crtc->Get())) {
         if (plane->GetType() == DRM_PLANE_TYPE_OVERLAY) {
@@ -190,7 +191,6 @@ auto DrmDisplayPipeline::GetUsablePlanes()
       }
     }
   }
-
   return planes;
 }
 

--- a/drm/DrmDisplayPipeline.h
+++ b/drm/DrmDisplayPipeline.h
@@ -72,7 +72,7 @@ struct DrmDisplayPipeline {
   static auto CreatePipeline(DrmConnector &connector)
       -> std::unique_ptr<DrmDisplayPipeline>;
 
-  auto GetUsablePlanes()
+  auto GetUsablePlanes(uint32_t video_layer_number)
       -> std::vector<std::shared_ptr<BindingOwner<DrmPlane>>>;
 
   auto AtomicDisablePipeline() -> int;

--- a/hwc2_device/HwcDisplay.cpp
+++ b/hwc2_device/HwcDisplay.cpp
@@ -532,7 +532,10 @@ HWC2::Error HwcDisplay::CreateComposition(AtomicCommitArgs &a_args) {
   bool use_client_layer = false;
   uint32_t client_z_order = UINT32_MAX;
   std::map<uint32_t, HwcLayer *> z_map;
+  uint32_t video_layer_number = 0;
   for (std::pair<const hwc2_layer_t, HwcLayer> &l : layers_) {
+    if (l.second.IsVideoLayer())
+      video_layer_number++;
     switch (l.second.GetValidatedType()) {
       case HWC2::Composition::Device:
         z_map.emplace(std::make_pair(l.second.GetZOrder(), &l.second));
@@ -578,7 +581,8 @@ HWC2::Error HwcDisplay::CreateComposition(AtomicCommitArgs &a_args) {
    * in between of ValidateDisplay() and PresentDisplay() calls
    */
   current_plan_ = DrmKmsPlan::CreateDrmKmsPlan(GetPipe(),
-                                               std::move(composition_layers));
+                                               std::move(composition_layers),
+                                               video_layer_number);
   if (!current_plan_) {
     if (!a_args.test_only) {
       ALOGE("Failed to create DrmKmsPlan");

--- a/hwc2_device/HwcLayer.cpp
+++ b/hwc2_device/HwcLayer.cpp
@@ -21,7 +21,7 @@
 #include "HwcDisplay.h"
 #include "bufferinfo/BufferInfoGetter.h"
 #include "utils/log.h"
-
+#include "cros_gralloc_handle.h"
 namespace android {
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -58,6 +58,39 @@ HWC2::Error HwcLayer::SetLayerBuffer(buffer_handle_t buffer,
   buffer_handle_updated_ = true;
 
   return HWC2::Error::None;
+}
+
+bool HwcLayer::IsVideoLayer() {
+  if (nullptr != buffer_handle_) {
+    cros_gralloc_handle *gr_handle = (cros_gralloc_handle *)(buffer_handle_);
+    if ((nullptr != gr_handle) && (IsSupportedMediaFormat(gr_handle->format)))
+      return true;
+  }
+  return false;
+}
+
+bool HwcLayer::IsSupportedMediaFormat(uint32_t format) {
+  switch (format) {
+	case DRM_FORMAT_NV12:
+	case DRM_FORMAT_NV16:
+	case DRM_FORMAT_P010:
+	case DRM_FORMAT_YVU420:
+	case DRM_FORMAT_YUV420:
+	case DRM_FORMAT_YUV422:
+	case DRM_FORMAT_YUV444:
+	case DRM_FORMAT_UYVY:
+	case DRM_FORMAT_YUYV:
+	case DRM_FORMAT_YVYU:
+	case DRM_FORMAT_VYUY:
+	case DRM_FORMAT_AYUV:
+	case DRM_FORMAT_NV12_Y_TILED_INTEL:
+	case DRM_FORMAT_NV21:
+	case DRM_FORMAT_YVU420_ANDROID:
+	  return true;
+	default:
+	  break;
+  }
+  return false;
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/hwc2_device/HwcLayer.h
+++ b/hwc2_device/HwcLayer.h
@@ -23,7 +23,8 @@
 #include "compositor/LayerData.h"
 
 namespace android {
-
+#define DRM_FORMAT_YVU420_ANDROID fourcc_code('9', '9', '9', '7')
+#define DRM_FORMAT_P010		fourcc_code('P', '0', '1', '0')
 class HwcDisplay;
 
 class HwcLayer {
@@ -61,6 +62,8 @@ class HwcLayer {
   auto &GetLayerData() {
     return layer_data_;
   }
+
+  bool IsVideoLayer();
 
   // Layer hooks
   HWC2::Error SetCursorPosition(int32_t /*x*/, int32_t /*y*/);
@@ -122,7 +125,7 @@ class HwcLayer {
   void ImportFb();
   bool bi_get_failed_{};
   bool fb_import_failed_{};
-
+  bool IsSupportedMediaFormat(uint32_t format);
   /* SwapChain Cache */
  public:
   void SwChainClearCache();


### PR DESCRIPTION
Due to video layer update frequently, we need
force video layer to use plane for composition even we don't set prop 'vendor.hwcomposer.planes.enabling'

Tracked-On: OAM-108575