### PR TITLE
drm_hwcomposer: Get CM properties only when required

### DIFF
--- a/drm/DrmCrtc.cpp
+++ b/drm/DrmCrtc.cpp
@@ -61,22 +61,24 @@ auto DrmCrtc::CreateInstance(DrmDevice &dev, uint32_t crtc_id, uint32_t index)
     return {};
   }
 
-  ret = GetCrtcProperty(dev, *c, "CTM", &c->ctm_property_);
-  if (ret != 0) {
-    ALOGE("Failed to get CTM property");
-    return {};
-  }
+  if (dev.GetColorAdjustmentEnabling()) {
+    ret = GetCrtcProperty(dev, *c, "CTM", &c->ctm_property_);
+    if (ret != 0) {
+      ALOGE("Failed to get CTM property");
+      return {};
+    }
 
-  ret = GetCrtcProperty(dev, *c, "GAMMA_LUT", &c->gamma_lut_property_);
-  if (ret != 0) {
-    ALOGE("Failed to get GAMMA_LUT property");
-    return {};
-  }
+    ret = GetCrtcProperty(dev, *c, "GAMMA_LUT", &c->gamma_lut_property_);
+    if (ret != 0) {
+      ALOGE("Failed to get GAMMA_LUT property");
+      return {};
+    }
 
-  ret = GetCrtcProperty(dev, *c, "GAMMA_LUT_SIZE", &c->gamma_lut_size_property_);
-  if (ret != 0) {
-    ALOGE("Failed to get GAMMA_LUT_SIZE property");
-    return {};
+    ret = GetCrtcProperty(dev, *c, "GAMMA_LUT_SIZE", &c->gamma_lut_size_property_);
+    if (ret != 0) {
+      ALOGE("Failed to get GAMMA_LUT_SIZE property");
+      return {};
+    }
   }
 
   return c;


### PR DESCRIPTION
Currently, initialization of drm device would fail if there is no color management properties (CTM, gamma_lut and gamma_lut_size), which is the case for virtio-GPU.  But actually these properties are not required when color adjustment is disabled.

Only try to get these properties when color adjustment is required.

Test-done:
Boot Android VM with virtio-GPU for display.

Tracked-On: OAM-113088