### PR TITLE
Add color matrix libdrm interfaces

### DIFF
--- a/drm/DrmAtomicStateManager.h
+++ b/drm/DrmAtomicStateManager.h
@@ -24,6 +24,7 @@
 #include <optional>
 #include <sstream>
 #include <tuple>
+#include <system/graphics.h>
 
 #include "compositor/DrmKmsPlan.h"
 #include "compositor/LayerData.h"
@@ -40,7 +41,7 @@ struct AtomicCommitArgs {
   std::optional<DrmMode> display_mode;
   std::optional<bool> active;
   std::shared_ptr<DrmKmsPlan> composition;
-  bool color_adjustment = false;
+  int32_t color_adjustment = 0;
 
   /* out */
   UniqueFd out_fence;
@@ -55,6 +56,13 @@ struct gamma_colors {
   float red;
   float green;
   float blue;
+};
+
+struct drm_color_ctm_post_offset {
+  /* Data is U0.16 fixed point format. */
+  __u16 red;
+  __u16 green;
+  __u16 blue;
 };
 
 class PresentTrackerThread {
@@ -104,7 +112,8 @@ class DrmAtomicStateManager {
   auto SetColorTransformMatrix(
       double *color_transform_matrix,
       int32_t color_transform_hint) -> int;
-  auto ApplyPendingCTM(struct drm_color_ctm *ctm) -> int;
+  auto ApplyPendingCTM(struct drm_color_ctm *ctm,
+		  struct drm_color_ctm_post_offset *ctm_post_offset) -> int;
 
   auto SetColorCorrection(struct gamma_colors gamma,
                                     uint32_t contrast_c,

--- a/drm/DrmCrtc.cpp
+++ b/drm/DrmCrtc.cpp
@@ -68,6 +68,12 @@ auto DrmCrtc::CreateInstance(DrmDevice &dev, uint32_t crtc_id, uint32_t index)
       return {};
     }
 
+    ret = GetCrtcProperty(dev, *c, "CTM_POST_OFFSET", &c->ctm_post_offset_property_);
+    if (ret != 0) {
+      ALOGE("Failed to get CTM_POST_OFFSET property");
+      return {};
+    }
+
     ret = GetCrtcProperty(dev, *c, "GAMMA_LUT", &c->gamma_lut_property_);
     if (ret != 0) {
       ALOGE("Failed to get GAMMA_LUT property");

--- a/drm/DrmCrtc.h
+++ b/drm/DrmCrtc.h
@@ -71,6 +71,10 @@ class DrmCrtc : public PipelineBindable<DrmCrtc> {
    return ctm_property_;
  }
 
+ auto &GetCtmPostOffsetProperty() const {
+   return ctm_post_offset_property_;
+ }
+
  auto &GetGammaLutProperty() const {
    return gamma_lut_property_;
  }
@@ -91,6 +95,7 @@ class DrmCrtc : public PipelineBindable<DrmCrtc> {
   DrmProperty mode_property_;
   DrmProperty out_fence_ptr_property_;
   DrmProperty ctm_property_;
+  DrmProperty ctm_post_offset_property_;
   DrmProperty gamma_lut_property_;
   DrmProperty gamma_lut_size_property_;
 

--- a/drm/DrmDevice.cpp
+++ b/drm/DrmDevice.cpp
@@ -117,10 +117,10 @@ auto DrmDevice::Init(const char *path) -> int {
   max_resolution_ = std::pair<uint32_t, uint32_t>(res->max_width,
                                                   res->max_height);
 
-  color_adjustment_enabling_ = false;
+  color_adjustment_enabling_ = 0;
   memset(property, 0 , PROPERTY_VALUE_MAX);
   property_get("vendor.hwcomposer.color.adjustment.enabling", property, "0");
-  color_adjustment_enabling_ = atoi(property) != 0 ? true : false;
+  color_adjustment_enabling_ = atoi(property) < 0 ? 0 : atoi(property);
   ALOGD("COLOR_ The property 'vendor.hwcomposer.color.adjustment.enabling' value is %d", color_adjustment_enabling_);
 
   for (int i = 0; i < res->count_crtcs; ++i) {

--- a/drm/DrmDevice.h
+++ b/drm/DrmDevice.h
@@ -138,7 +138,7 @@ public:
   bool preferred_mode_limit_;
   bool planes_enabling_;
   int32_t planes_num_;
-  bool color_adjustment_enabling_;
+  int32_t color_adjustment_enabling_;
 };
 }  // namespace android
 

--- a/hwc2_device/HwcDisplay.h
+++ b/hwc2_device/HwcDisplay.h
@@ -48,7 +48,7 @@ class HwcDisplay {
   std::vector<HwcLayer *> GetOrderLayersByZPos();
 
   void ClearDisplay();
-
+  int64_t FloatToFixedPoint(float value) const;
   std::string Dump();
 
   // HWC Hooks


### PR DESCRIPTION
Add color matrix and matrix offset libdrm interfaces to enable saturation/hue/contrast/brightness adjustment.

Tracked-On: OAM-113088