### PR TITLE
Set up display color correction for contrast and luminance

### DIFF
--- a/.ci/android_headers/hardware/hwcomposer2.h
+++ b/.ci/android_headers/hardware/hwcomposer2.h
@@ -268,6 +268,7 @@ typedef enum {
     HWC2_FUNCTION_SET_CLIENT_TARGET,
     HWC2_FUNCTION_SET_COLOR_MODE,
     HWC2_FUNCTION_SET_COLOR_TRANSFORM,
+    HWC2_FUNCTION_SET_COLOR_TRANSFORM_CORRECTION,
     HWC2_FUNCTION_SET_CURSOR_POSITION,
     HWC2_FUNCTION_SET_LAYER_BLEND_MODE,
     HWC2_FUNCTION_SET_LAYER_BUFFER,
@@ -625,6 +626,8 @@ static inline const char* getFunctionDescriptorName(
         case HWC2_FUNCTION_SET_CLIENT_TARGET: return "SetClientTarget";
         case HWC2_FUNCTION_SET_COLOR_MODE: return "SetColorMode";
         case HWC2_FUNCTION_SET_COLOR_TRANSFORM: return "SetColorTransform";
+        case HWC2_FUNCTION_SET_COLOR_TRANSFORM_CORRECTION: 
+            return "SetColorTransformCorrection";
         case HWC2_FUNCTION_SET_CURSOR_POSITION: return "SetCursorPosition";
         case HWC2_FUNCTION_SET_LAYER_BLEND_MODE: return "SetLayerBlendMode";
         case HWC2_FUNCTION_SET_LAYER_BUFFER: return "SetLayerBuffer";
@@ -910,6 +913,7 @@ enum class FunctionDescriptor : int32_t {
     SetClientTarget = HWC2_FUNCTION_SET_CLIENT_TARGET,
     SetColorMode = HWC2_FUNCTION_SET_COLOR_MODE,
     SetColorTransform = HWC2_FUNCTION_SET_COLOR_TRANSFORM,
+    SetColorTransformCorrection = HWC2_FUNCTION_SET_COLOR_TRANSFORM_CORRECTION,
     SetCursorPosition = HWC2_FUNCTION_SET_CURSOR_POSITION,
     SetLayerBlendMode = HWC2_FUNCTION_SET_LAYER_BLEND_MODE,
     SetLayerBuffer = HWC2_FUNCTION_SET_LAYER_BUFFER,
@@ -2010,6 +2014,32 @@ typedef int32_t /*hwc2_error_t*/ (*HWC2_PFN_SET_COLOR_MODE_WITH_RENDER_INTENT)(
 typedef int32_t /*hwc2_error_t*/ (*HWC2_PFN_SET_COLOR_TRANSFORM)(
         hwc2_device_t* device, hwc2_display_t display, const float* matrix,
         int32_t /*android_color_transform_t*/ hint);
+
+/* setColorTransformCorrection(..., contrast, luminance)
+ * Descriptor: HWC2_FUNCTION_SET_COLOR_TRANSFORM
+ * Must be provided by all HWC2 devices
+ *
+ * Sets a color transform which will be applied after composition.
+ *
+ * If the device is not capable of using the value to apply
+ * the desired color transform, it should force all layers to client composition
+ * during validateDisplay.
+ *
+ * If HWC2_CAPABILITY_SKIP_CLIENT_COLOR_TRANSFORM is present, then the client
+ * will never apply the color transform during client composition, even if all
+ * layers are being composed by the client.
+ *
+ * Parameters:
+ *   contrast - an integer representing the transform contrast
+ *   luminance - an integer representing the transform luminance
+ *
+ * Returns HWC2_ERROR_NONE or one of the following errors:
+ *   HWC2_ERROR_BAD_DISPLAY - an invalid display handle was passed in
+ *   HWC2_ERROR_BAD_PARAMETER - hint is not a valid color transform hint
+ */
+typedef int32_t /*hwc2_error_t*/ (*HWC2_PFN_SET_COLOR_TRANSFORM_CORRECTION)(
+        hwc2_device_t* device, hwc2_display_t display, int32_t contrast, 
+        int32_t luminance);
 
 /* getPerFrameMetadataKeys(..., outKeys)
  * Descriptor: HWC2_FUNCTION_GET_PER_FRAME_METADATA_KEYS

--- a/drm/DrmAtomicStateManager.h
+++ b/drm/DrmAtomicStateManager.h
@@ -24,7 +24,7 @@
 #include <optional>
 #include <sstream>
 #include <tuple>
-
+#include <system/graphics.h>
 #include "compositor/DrmKmsPlan.h"
 #include "compositor/LayerData.h"
 #include "drm/DrmPlane.h"
@@ -40,7 +40,7 @@ struct AtomicCommitArgs {
   std::optional<DrmMode> display_mode;
   std::optional<bool> active;
   std::shared_ptr<DrmKmsPlan> composition;
-  bool color_adjustment = false;
+  int32_t color_adjustment = 0;
 
   /* out */
   UniqueFd out_fence;

--- a/drm/DrmCrtc.cpp
+++ b/drm/DrmCrtc.cpp
@@ -61,24 +61,22 @@ auto DrmCrtc::CreateInstance(DrmDevice &dev, uint32_t crtc_id, uint32_t index)
     return {};
   }
 
-  if (dev.GetColorAdjustmentEnabling()) {
-    ret = GetCrtcProperty(dev, *c, "CTM", &c->ctm_property_);
-    if (ret != 0) {
-      ALOGE("Failed to get CTM property");
-      return {};
-    }
+  ret = GetCrtcProperty(dev, *c, "CTM", &c->ctm_property_);
+  if (ret != 0) {
+    ALOGE("Failed to get CTM property");
+    return {};
+  }
 
-    ret = GetCrtcProperty(dev, *c, "GAMMA_LUT", &c->gamma_lut_property_);
-    if (ret != 0) {
-      ALOGE("Failed to get GAMMA_LUT property");
-      return {};
-    }
+  ret = GetCrtcProperty(dev, *c, "GAMMA_LUT", &c->gamma_lut_property_);
+  if (ret != 0) {
+    ALOGE("Failed to get GAMMA_LUT property");
+    return {};
+  }
 
-    ret = GetCrtcProperty(dev, *c, "GAMMA_LUT_SIZE", &c->gamma_lut_size_property_);
-    if (ret != 0) {
-      ALOGE("Failed to get GAMMA_LUT_SIZE property");
-      return {};
-    }
+  ret = GetCrtcProperty(dev, *c, "GAMMA_LUT_SIZE", &c->gamma_lut_size_property_);
+  if (ret != 0) {
+    ALOGE("Failed to get GAMMA_LUT_SIZE property");
+    return {};
   }
 
   return c;

--- a/drm/DrmDevice.cpp
+++ b/drm/DrmDevice.cpp
@@ -117,10 +117,10 @@ auto DrmDevice::Init(const char *path) -> int {
   max_resolution_ = std::pair<uint32_t, uint32_t>(res->max_width,
                                                   res->max_height);
 
-  color_adjustment_enabling_ = false;
+  color_adjustment_enabling_ = 0;
   memset(property, 0 , PROPERTY_VALUE_MAX);
   property_get("vendor.hwcomposer.color.adjustment.enabling", property, "0");
-  color_adjustment_enabling_ = atoi(property) != 0 ? true : false;
+  color_adjustment_enabling_ = atoi(property) < 0 ? 0 : atoi(property);
   ALOGD("COLOR_ The property 'vendor.hwcomposer.color.adjustment.enabling' value is %d", color_adjustment_enabling_);
 
   for (int i = 0; i < res->count_crtcs; ++i) {

--- a/drm/DrmDevice.h
+++ b/drm/DrmDevice.h
@@ -138,7 +138,7 @@ public:
   bool preferred_mode_limit_;
   bool planes_enabling_;
   int32_t planes_num_;
-  bool color_adjustment_enabling_;
+  int32_t color_adjustment_enabling_;
 };
 }  // namespace android
 

--- a/hwc2_device/HwcDisplay.h
+++ b/hwc2_device/HwcDisplay.h
@@ -48,7 +48,7 @@ class HwcDisplay {
   std::vector<HwcLayer *> GetOrderLayersByZPos();
 
   void ClearDisplay();
-
+  int64_t FloatToFixedPoint(float value) const;
   std::string Dump();
 
   // HWC Hooks
@@ -114,6 +114,7 @@ class HwcDisplay {
                               int32_t dataspace, hwc_region_t damage);
   HWC2::Error SetColorMode(int32_t mode);
   HWC2::Error SetColorTransform(const float *matrix, int32_t hint);
+  HWC2::Error SetColorTransformCorrection(int32_t contrast, int32_t luminance);
   HWC2::Error SetOutputBuffer(buffer_handle_t buffer, int32_t release_fence);
   HWC2::Error SetPowerMode(int32_t mode);
   HWC2::Error SetVsyncEnabled(int32_t enabled);

--- a/hwc2_device/hwc2_device.cpp
+++ b/hwc2_device/hwc2_device.cpp
@@ -233,6 +233,10 @@ static hwc2_function_pointer_t HookDevGetFunction(struct hwc2_device * /*dev*/,
       return ToHook<HWC2_PFN_SET_COLOR_TRANSFORM>(
           DisplayHook<decltype(&HwcDisplay::SetColorTransform),
                       &HwcDisplay::SetColorTransform, const float *, int32_t>);
+    case HWC2::FunctionDescriptor::SetColorTransformCorrection:
+      return ToHook<HWC2_PFN_SET_COLOR_TRANSFORM_CORRECTION>(
+          DisplayHook<decltype(&HwcDisplay::SetColorTransformCorrection),
+                      &HwcDisplay::SetColorTransformCorrection, int32_t, int32_t>);
     case HWC2::FunctionDescriptor::SetOutputBuffer:
       return ToHook<HWC2_PFN_SET_OUTPUT_BUFFER>(
           DisplayHook<decltype(&HwcDisplay::SetOutputBuffer),


### PR DESCRIPTION
Pass down the new contrsat and luminance value to hwc to adjust the display color using gamma algorithm.

Test-done:
    Android boot and navigation tested

Tracked-On: OAM-114024