### PR TITLE
Return HWC2_ERROR_NONE to pass VTS SetDisplayBrightness

### DIFF
--- a/hwc3-server/default/impl/HalImpl.cpp
+++ b/hwc3-server/default/impl/HalImpl.cpp
@@ -680,7 +680,7 @@ int32_t HalImpl::getSupportedContentTypes(int64_t display, std::vector<ContentTy
 }
 
 int32_t HalImpl::flushDisplayBrightnessChange([[maybe_unused]] int64_t display) {
-    return HWC2_ERROR_UNSUPPORTED;
+    return HWC2_ERROR_NONE;
 }
 
 int32_t HalImpl::presentDisplay(int64_t display, ndk::ScopedFileDescriptor& fence,


### PR DESCRIPTION
Our HWC does not support set display brightness and function flushDisplayBrightnessChange returns HWC2_ERROR_UNSUPPORTED, which results in vts case SetDisplayBrightness failed.

Let flushDisplayBrightnessChange return HWC2_ERROR_NONE to pass the vts test.

Test Done:
run vts -m VtsHalGraphicsComposer3_TargetTest

Tracked-On: OAM-118706