### PR TITLE
Return EX_UNSUPPORTED to pass VTS SetRefreshRateChangedCallbackDebug_…

### DIFF
--- a/hwc3-server/default/ComposerClient.cpp
+++ b/hwc3-server/default/ComposerClient.cpp
@@ -421,7 +421,7 @@ ndk::ScopedAStatus ComposerClient::setIdleTimerEnabled(int64_t display, int32_t 
 
 ndk::ScopedAStatus ComposerClient::setRefreshRateChangedCallbackDebugEnabled(int64_t displayId,
                                                                bool enabled) {
-    return ndk::ScopedAStatus::ok();
+    return TO_BINDER_STATUS(EX_UNSUPPORTED);
 }
 
 void ComposerClient::HalEventCallback::onHotplug(int64_t display, bool connected) {


### PR DESCRIPTION
…Unsupported

Currently, our hwc doesn't support REFRESH_RATE_CHANGED_CALLBACK_DEBUG, return EX_UNSUPPORTED to pass VTS test.

Test Done:
run vts -m VtsHalGraphicsComposer3_TargetTest

Tracked-On: OAM-118748