### PR TITLE
Fix VtsHalGraphicsComposer3_TargetTest failure

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -37,6 +37,9 @@ cc_library_static {
 cc_defaults {
     name: "hwcomposer.drm_defaults",
 
+    defaults: [
+        "android.hardware.graphics.composer3-ndk_shared",
+    ],
     shared_libs: [
         "libcutils",
         "libdrm",
@@ -50,6 +53,9 @@ cc_defaults {
 
     include_dirs: ["vendor/intel/external/drm-hwcomposer"],
 
+    header_libs: [
+        "android.hardware.graphics.composer3-command-buffer",
+    ],
     static_libs: ["libdrmhwc_utils"],
 
     cflags: [

--- a/backend/Backend.cpp
+++ b/backend/Backend.cpp
@@ -18,6 +18,7 @@
 
 #include <climits>
 
+#include <aidl/android/hardware/graphics/composer3/Composition.h>
 #include "BackendManager.h"
 #include "bufferinfo/BufferInfoGetter.h"
 
@@ -30,6 +31,10 @@ HWC2::Error Backend::ValidateDisplay(HwcDisplay *display, uint32_t *num_types,
 
   auto layers = display->GetOrderLayersByZPos();
 
+  for (auto l : layers) {
+    if ((uint32_t)l->GetSfType() == (uint32_t)aidl::android::hardware::graphics::composer3::Composition::DISPLAY_DECORATION)
+      return HWC2::Error::Unsupported;
+  }
   int client_start = -1;
   size_t client_size = 0;
 

--- a/hwc2_device/HwcDisplay.h
+++ b/hwc2_device/HwcDisplay.h
@@ -27,6 +27,8 @@
 #include "drm/ResourceManager.h"
 #include "drm/VSyncWorker.h"
 #include "hwc2_device/HwcLayer.h"
+#include "utils/hwc3.h"
+using namespace aidl::android::hardware::graphics::composer3;
 
 namespace android {
 
@@ -118,6 +120,8 @@ class HwcDisplay {
   HWC2::Error SetPowerMode(int32_t mode);
   HWC2::Error SetVsyncEnabled(int32_t enabled);
   HWC2::Error ValidateDisplay(uint32_t *num_types, uint32_t *num_requests);
+  HWC3::Error setExpectedPresentTime(
+      const std::optional<ClockMonotonicTimestamp>& expectedPresentTime);
   HwcLayer *get_layer(hwc2_layer_t layer) {
     auto it = layers_.find(layer);
     if (it == layers_.end())
@@ -230,6 +234,7 @@ class HwcDisplay {
 
   std::shared_ptr<DrmKmsPlan> current_plan_;
 
+  std::optional<ClockMonotonicTimestamp> expectedPresentTime_ = std::nullopt;
   uint32_t frame_no_ = 0;
   Stats total_stats_;
   Stats prev_stats_;

--- a/hwc2_device/hwc2_device.cpp
+++ b/hwc2_device/hwc2_device.cpp
@@ -375,7 +375,12 @@ static hwc2_function_pointer_t HookDevGetFunction(struct hwc2_device * /*dev*/,
                     const int32_t *, const float *>);
     case HWC2::FunctionDescriptor::Invalid:
     default:
-      return nullptr;
+      if (descriptor == HWC3::HWC3_FUNCTION_SET_EXPECTED_PRESENT_TIME)
+        return ToHook<HWC3::HWC3_PFN_SET_EXPECTED_PRESENT_TIME>(
+            DisplayHook<decltype(&HwcDisplay::setExpectedPresentTime),
+                        &HwcDisplay::setExpectedPresentTime, const std::optional<ClockMonotonicTimestamp>&>);
+      else
+        return nullptr;
   }
 }
 

--- a/hwc3-server/default/Android.bp
+++ b/hwc3-server/default/Android.bp
@@ -43,6 +43,7 @@ cc_binary {
         "impl",
     ],
     include_dirs: [ 
+	"vendor/intel/external/drm-hwcomposer",
     ],
     header_libs: [
         "android.hardware.graphics.composer3-command-buffer",

--- a/hwc3-server/default/impl/HalImpl.h
+++ b/hwc3-server/default/impl/HalImpl.h
@@ -27,6 +27,7 @@
 #undef HWC2_INCLUDE_STRINGIFICATION
 #undef HWC2_USE_CPP11
 
+#include "utils/hwc3.h"
 namespace aidl::android::hardware::graphics::composer3::impl {
 
 // Forward aidl call to HWC
@@ -160,6 +161,8 @@ private:
     template <typename T>
     bool initDispatch(hwc2_function_descriptor_t desc, T* outPfn);
 
+    template <typename T>
+    bool initDispatch(HWC3::hwc3_function_descriptor_t desc, T* outPfn);
     bool initDispatch();
     void initCaps();
 
@@ -243,6 +246,7 @@ private:
         HWC2_PFN_GET_CLIENT_TARGET_PROPERTY getClientTargetProperty;
         HWC2_PFN_SET_LAYER_GENERIC_METADATA setLayerGenericMetadata;
         HWC2_PFN_GET_LAYER_GENERIC_METADATA_KEY getLayerGenericMetadataKey;
+        HWC3::HWC3_PFN_SET_EXPECTED_PRESENT_TIME setExpectedPresentTime;
     } mDispatch = {};
 
     hwc2_device_t* mDevice;

--- a/utils/hwc3.h
+++ b/utils/hwc3.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROID_HWC3_H
+#define ANDROID_HWC3_H
+
+#include <inttypes.h>
+#include <hardware/hwcomposer2.h>
+#include <string>
+#include <aidl/android/hardware/graphics/composer3/IComposerClient.h>
+#include <android-base/logging.h>
+#include <log/log.h>
+#include <utils/Trace.h>
+using namespace aidl::android::hardware::graphics::composer3;
+namespace HWC3 {
+enum class Error : int32_t {
+  None = 0,
+  BadConfig = aidl::android::hardware::graphics::composer3::IComposerClient::
+      EX_BAD_CONFIG,
+  BadDisplay = aidl::android::hardware::graphics::composer3::IComposerClient::
+      EX_BAD_DISPLAY,
+  BadLayer = aidl::android::hardware::graphics::composer3::IComposerClient::
+      EX_BAD_LAYER,
+  BadParameter = aidl::android::hardware::graphics::composer3::IComposerClient::
+      EX_BAD_PARAMETER,
+  NoResources = aidl::android::hardware::graphics::composer3::IComposerClient::
+      EX_NO_RESOURCES,
+  NotValidated = aidl::android::hardware::graphics::composer3::IComposerClient::
+      EX_NOT_VALIDATED,
+  Unsupported = aidl::android::hardware::graphics::composer3::IComposerClient::
+      EX_UNSUPPORTED,
+  SeamlessNotAllowed = aidl::android::hardware::graphics::composer3::
+      IComposerClient::EX_SEAMLESS_NOT_ALLOWED,
+};
+
+typedef enum {
+    HWC3_FUNCTION_SET_EXPECTED_PRESENT_TIME = HWC2_FUNCTION_GET_LAYER_GENERIC_METADATA_KEY + 1,
+}hwc3_function_descriptor_t;
+
+typedef int32_t /*hwc_error_t*/ (*HWC3_PFN_SET_EXPECTED_PRESENT_TIME)(hwc2_device_t* device,
+        hwc2_display_t display, const std::optional<ClockMonotonicTimestamp>& expectedPresentTime);
+}  // namespace HWC3
+
+#endif
+


### PR DESCRIPTION
If composition type is Composition::DISPLAY_DECORATION return HWC2::Error::Unsupported.
Check if parameter mode is valid in GetRenderIntents. Implement interface setExpectedPresentTime.

Tracked-On: OAM-119741