### PR TITLE
Ensure hwc use device composition for Video Layer

### DIFF
--- a/backend/Backend.cpp
+++ b/backend/Backend.cpp
@@ -22,6 +22,11 @@
 #include "BackendManager.h"
 #include "bufferinfo/BufferInfoGetter.h"
 
+#ifdef LOG_TAG
+#undef LOG_TAG
+#endif
+#define LOG_TAG "hwc-backend"
+
 namespace android {
 
 HWC2::Error Backend::ValidateDisplay(HwcDisplay *display, uint32_t *num_types,
@@ -71,19 +76,47 @@ HWC2::Error Backend::ValidateDisplay(HwcDisplay *display, uint32_t *num_types,
 }
 
 std::tuple<int, size_t> Backend::GetClientLayers(
-    HwcDisplay *display, const std::vector<HwcLayer *> &layers) {
+    HwcDisplay *display, std::vector<HwcLayer *> &layers) {
   int client_start = -1;
   size_t client_size = 0;
 
+  int device_start = -1;
+  size_t device_size = 0;
   for (size_t z_order = 0; z_order < layers.size(); ++z_order) {
     if (IsClientLayer(display, layers[z_order])) {
       if (client_start < 0)
         client_start = (int)z_order;
       client_size = (z_order - client_start) + 1;
     }
+    if (IsVideoLayer(layers[z_order])) {
+      if (device_start < 0)
+        device_start = (int)z_order;
+      device_size = (z_order - device_start) + 1;
+    }
+  }
+  if (device_size == 0)
+    return GetExtraClientRange(display, layers, client_start, client_size);
+  else {
+    bool status = true;
+    MarkValidated(layers, client_start, client_size);
+    for (size_t z_order = 0; z_order < layers.size(); ++z_order) {
+      if (z_order >= client_start &&
+          z_order <= (client_start + client_size - 1) &&
+          IsVideoLayer(layers[z_order]))
+        status = false;
+
+      if (z_order >= device_start &&
+          z_order <= (device_start + device_size - 1) &&
+          layers[z_order]->GetValidatedType() == HWC2::Composition::Client)
+        status = false;
+    }
+    if (!status) {
+      ALOGE("status is abnormal");
+      return GetExtraClientRange(display, layers, client_start, client_size);
+    }
+    return GetExtraClientRange2(display, layers, client_start, client_size, device_start, device_size);
   }
 
-  return GetExtraClientRange(display, layers, client_start, client_size);
 }
 
 bool Backend::IsClientLayer(HwcDisplay *display, HwcLayer *layer) {
@@ -92,6 +125,13 @@ bool Backend::IsClientLayer(HwcDisplay *display, HwcLayer *layer) {
          display->color_transform_hint() != HAL_COLOR_TRANSFORM_IDENTITY ||
          (layer->GetLayerData().pi.RequireScalingOrPhasing() &&
           display->GetHwc2()->GetResMan().ForcedScalingWithGpu());
+}
+
+bool Backend::IsVideoLayer(HwcLayer *layer) {
+  std::optional<BufferInfo> bi;
+  if (layer->GetBufferHandle())
+    bi = BufferInfoGetter::GetInstance()->GetBoInfo(layer->GetBufferHandle());
+  return bi && bi->usage & GRALLOC_USAGE_HW_VIDEO_ENCODER;
 }
 
 bool Backend::HardwareSupportsLayerType(HWC2::Composition comp_type) {
@@ -166,6 +206,97 @@ std::tuple<int, int> Backend::GetExtraClientRange(
   return std::make_tuple(client_start, client_size);
 }
 
+std::tuple<int, int> Backend::GetExtraClientRange2(
+    HwcDisplay *display, const std::vector<HwcLayer *> &layers,
+    int client_start, size_t client_size, int device_start, size_t device_size) {
+  auto planes = display->GetPipe().GetUsablePlanes();
+  size_t avail_planes = planes.size();
+
+  /*
+   * If more layers then planes, save one plane
+   * for client composited layers
+   */
+  if (avail_planes < display->layers().size())
+    avail_planes--;
+
+  if (avail_planes < device_size) {
+    ALOGE("too many device video layers(%zd), no enough planes(%zd) to use", device_size, avail_planes);
+    return GetExtraClientRange(display, layers, client_start, client_size);
+  } else if (avail_planes == device_size) {
+    if (device_start != 0 && (device_start +  device_size) != layers.size()) {
+      ALOGE("status is abnormal");
+      return GetExtraClientRange(display, layers, client_start, client_size);
+    }
+
+    if (device_start == 0)
+      return std::make_tuple(device_start + device_size, layers.size() - device_size);
+    else
+      return std::make_tuple(0, layers.size() - device_size);
+  } else {
+    if (client_start == -1) {
+      int extra_device = std::min(layers.size() - device_size - client_size, avail_planes - device_size);
+      int prepend = device_start;
+      int append = layers.size() - (device_start + device_size);
+      if (std::min(prepend, append) > extra_device) {
+        ALOGE("status is abnormal");
+        return GetExtraClientRange(display, layers, client_start, client_size);
+      }
+
+      if (prepend == std::min(prepend, append)) {
+        int remain = extra_device - prepend;
+        return std::make_tuple(device_start + device_size + remain, layers.size() - extra_device - device_size);
+      }
+      if (append == std::min(prepend, append)) {
+        return std::make_tuple(0, layers.size() - extra_device - device_size);
+      }
+    } else {
+      int extra_device = std::min(layers.size() - device_size - client_size, avail_planes - device_size);
+      if (client_start > device_start) {
+        int prepend = device_start;
+        int midpend = client_start - (device_start + device_size);
+        int append = layers.size() - (client_start + client_size);
+        if (prepend > extra_device) {
+          ALOGE("status is abnormal");
+          return GetExtraClientRange(display, layers, client_start, client_size);
+        }
+        int remain = extra_device - prepend;
+        if (remain == 0) {
+          return std::make_tuple(device_start + device_size, layers.size() - extra_device - device_size);
+        } else {
+          midpend = std::min(midpend, remain);
+          if (midpend == remain) {
+            return std::make_tuple(device_start + device_size + midpend,
+                                    layers.size() - prepend - midpend - device_size);
+          } else {
+            return std::make_tuple(device_start + device_size + midpend,
+                                  layers.size() - prepend - midpend - std::min(remain - midpend, append) - device_size);
+          }
+        }
+      } else {
+        int prepend = client_start;
+        int midpend = device_start - (client_start + client_size);
+        int append = layers.size() - (device_start + device_size);
+        if (append > extra_device) {
+          ALOGE("status is abnormal");
+          return GetExtraClientRange(display, layers, client_start, client_size);
+        }
+        int remain = extra_device - append;
+        if (remain == 0)
+          return std::make_tuple(0, layers.size() - extra_device - device_size);
+        else {
+          midpend = std::min(midpend, remain);
+          if (midpend == remain) {
+            return std::make_tuple(0, layers.size() - append - midpend - device_size);
+          } else {
+            return std::make_tuple(std::min(remain - midpend, prepend),
+                    layers.size() - append - midpend - std::min(remain - midpend, prepend) - device_size);
+          }
+        }
+      }
+    }
+  }
+  return GetExtraClientRange(display, layers, client_start, client_size);
+}
 // clang-format off
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, cert-err58-cpp)
 REGISTER_BACKEND("generic", Backend);

--- a/backend/Backend.h
+++ b/backend/Backend.h
@@ -27,9 +27,9 @@ class Backend {
   virtual HWC2::Error ValidateDisplay(HwcDisplay *display, uint32_t *num_types,
                                       uint32_t *num_requests);
   virtual std::tuple<int, size_t> GetClientLayers(
-      HwcDisplay *display, const std::vector<HwcLayer *> &layers);
+      HwcDisplay *display, std::vector<HwcLayer *> &layers);
   virtual bool IsClientLayer(HwcDisplay *display, HwcLayer *layer);
-
+  virtual bool IsVideoLayer(HwcLayer *layer);
  protected:
   static bool HardwareSupportsLayerType(HWC2::Composition comp_type);
   static uint32_t CalcPixOps(const std::vector<HwcLayer *> &layers,
@@ -39,6 +39,9 @@ class Backend {
   static std::tuple<int, int> GetExtraClientRange(
       HwcDisplay *display, const std::vector<HwcLayer *> &layers,
       int client_start, size_t client_size);
+  static std::tuple<int, int> GetExtraClientRange2(
+      HwcDisplay *display, const std::vector<HwcLayer *> &layers,
+      int client_start, size_t client_size, int device_start, size_t device_size);
 };
 }  // namespace android
 

--- a/bufferinfo/BufferInfo.h
+++ b/bufferinfo/BufferInfo.h
@@ -46,6 +46,7 @@ struct BufferInfo {
   uint32_t format; /* DRM_FORMAT_* from drm_fourcc.h */
   uint32_t pitches[kBufferMaxPlanes];
   uint32_t offsets[kBufferMaxPlanes];
+  uint64_t usage;
   /* sizes[] is used only by mapper@4 metadata getter for internal purposes */
   uint32_t sizes[kBufferMaxPlanes];
   int prime_fds[kBufferMaxPlanes];

--- a/bufferinfo/BufferInfoMapperMetadata.cpp
+++ b/bufferinfo/BufferInfoMapperMetadata.cpp
@@ -100,6 +100,7 @@ auto BufferInfoMapperMetadata::GetBoInfo(buffer_handle_t handle)
     return {};
   }
 
+  mapper.getUsage(handle, &bi.usage);
   err = mapper.getPixelFormatModifier(handle, &bi.modifiers[0]);
   if (err != 0) {
     ALOGE("Failed to get DRM Modifier err=%d", err);

--- a/hwc2_device/HwcLayer.h
+++ b/hwc2_device/HwcLayer.h
@@ -114,6 +114,7 @@ class HwcLayer {
  public:
   void PopulateLayerData(bool test);
 
+  buffer_handle_t GetBufferHandle() {return buffer_handle_;}
   bool IsLayerUsableAsDevice() const {
     return !bi_get_failed_ && !fb_import_failed_ && buffer_handle_ != nullptr;
   }


### PR DESCRIPTION
Video layer, protected or non-protected, need to use
device composition, meanwhile hwc can use overlay planes,
so just layers number is not greater than available
planes number, hwc ensure use device composition for
video layer.

This commit target is to ensure use device composition
for video layer if layers number is greater than 
available planes number.

The main logic code is in GetExtraClientRange2. 
When device_size is less than or equal to avail_planes,
besides the planes used to compose video layer, the
remaining planes also need to be used to compose other
layers. GetExtraClientRange2 will return client_start,
client_size, then ValidateDisplay will set the client
composition according to client_start and client_size,
and the rest is device composition.

Because the number of available planes is limited,
GetExtraClientRange2 mainly do parameter checks under
this condition.

For example:

GetExtraClientRange2 before
z_order type    format
0
1
2       client  
3       client
4       device  video
5       
6       
7       

GetExtraClientRange2 after
z_order type    format
0       client
1       client
2       client  
3       client
4       device  video
5       device
6       device
7       device

z_order 2 and 3 are confirmed to use client composition
by IsClientLayer. z_order 4 is the video layer, which
needs device compsition. There are only 4 available planes,
and the remaining 3 planes can be used for z_order 5, 6, 7.

GetExtraClientRange2 returns client_start(0), client_size(4), 
and then MarkValidated will set 0~3 client composition and
4~7 device composition.

Tracked-On: OAM-123606