### PR TITLE
Use client composition for QNX/screencast display

### DIFF
--- a/backend/Backend.cpp
+++ b/backend/Backend.cpp
@@ -124,7 +124,8 @@ bool Backend::IsClientLayer(HwcDisplay *display, HwcLayer *layer) {
          !layer->IsLayerUsableAsDevice() ||
          display->color_transform_hint() != HAL_COLOR_TRANSFORM_IDENTITY ||
          (layer->GetLayerData().pi.RequireScalingOrPhasing() &&
-          display->GetHwc2()->GetResMan().ForcedScalingWithGpu());
+          display->GetHwc2()->GetResMan().ForcedScalingWithGpu()) ||
+         (!display->IsInHeadlessMode() && display->GetPipe().device->IsIvshmDev());
 }
 
 bool Backend::IsVideoLayer(HwcLayer *layer) {

--- a/drm/DrmDevice.cpp
+++ b/drm/DrmDevice.cpp
@@ -179,6 +179,7 @@ auto DrmDevice::Init(const char *path) -> int {
     }
   }
 
+  IsIvshmDev_ = IsIvshmDev(GetFd());
   return 0;
 }
 

--- a/drm/DrmDevice.h
+++ b/drm/DrmDevice.h
@@ -106,6 +106,7 @@ class DrmDevice {
                   DrmProperty *property) const;
 
   static auto IsIvshmDev(int fd) -> bool;
+  auto IsIvshmDev() {return IsIvshmDev_;}
 
  private:
   explicit DrmDevice(ResourceManager *res_man);
@@ -133,6 +134,7 @@ class DrmDevice {
   std::unique_ptr<DrmFbImporter> drm_fb_importer_;
 
   ResourceManager *const res_man_;
+  bool IsIvshmDev_ = false;
  public:
   bool preferred_mode_limit_ = false;
   bool planes_enabling_ = false;


### PR DESCRIPTION
Use client composition for QNX/screencast display

For QNX/screencast case, only need allocate framebuffer
from virtio-ivshmem, other layers even has scanout flag,
still allocate from i915 node. When only one layer exist,
still need use "CLIENT" for layer display due to i915
buffer can be used for display purpose.

Tracked-On: OAM-125928