### PR TITLE
Fix display black region while running KOG

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -51,7 +51,9 @@ cc_defaults {
         "libutils",
     ],
 
-    include_dirs: ["vendor/intel/external/drm-hwcomposer"],
+    include_dirs: [
+        "vendor/intel/external/drm-hwcomposer",
+        "kernel/linux-intel-lts2022"],
 
     header_libs: [
         "android.hardware.graphics.composer3-command-buffer",

--- a/compositor/DrmKmsPlan.h
+++ b/compositor/DrmKmsPlan.h
@@ -38,6 +38,12 @@ struct DrmKmsPlan {
   static auto CreateDrmKmsPlan(DrmDisplayPipeline &pipe,
                                std::vector<LayerData> composition)
       -> std::unique_ptr<DrmKmsPlan>;
+  static auto CreateDrmKmsPlan(DrmDisplayPipeline &pipe)
+      -> std::unique_ptr<DrmKmsPlan>;
+  void AddToPlan(LayerData layerdata);
+  DrmPlane* GetPlane(LayerData layerdata);
+  std::vector<std::shared_ptr<BindingOwner<DrmPlane>>> avail_planes;
+  int z_pos;
 };
 
 }  // namespace android

--- a/drm/DrmFbImporter.h
+++ b/drm/DrmFbImporter.h
@@ -37,7 +37,8 @@ namespace android {
 class DrmFbIdHandle {
  public:
   static auto CreateInstance(BufferInfo *bo, GemHandle first_gem_handle,
-                             DrmDevice &drm) -> std::shared_ptr<DrmFbIdHandle>;
+                             DrmDevice &drm,
+                             bool IsPixelBlendModeSupported) -> std::shared_ptr<DrmFbIdHandle>;
 
   ~DrmFbIdHandle();
   DrmFbIdHandle(DrmFbIdHandle &&) = delete;
@@ -67,7 +68,7 @@ class DrmFbImporter {
   auto operator=(const DrmFbImporter &) = delete;
   auto operator=(DrmFbImporter &&) = delete;
 
-  auto GetOrCreateFbId(BufferInfo *bo) -> std::shared_ptr<DrmFbIdHandle>;
+  auto GetOrCreateFbId(BufferInfo *bo, bool IsPixelBlendModeSupported) -> std::shared_ptr<DrmFbIdHandle>;
 
  private:
   void CleanupEmptyCacheElements() {

--- a/drm/DrmPlane.h
+++ b/drm/DrmPlane.h
@@ -39,6 +39,7 @@ class DrmPlane : public PipelineBindable<DrmPlane> {
       -> std::unique_ptr<DrmPlane>;
 
   bool IsCrtcSupported(const DrmCrtc &crtc) const;
+  bool IsPixBlendModeSupported() { return blend_property_ ? true : false;}
   bool IsValidForLayer(LayerData *layer);
 
   auto GetType() const {

--- a/drm/DrmVirtgpu.h
+++ b/drm/DrmVirtgpu.h
@@ -25,6 +25,7 @@
 #define DRM_VIRTGPU_H
 
 #include "drm.h"
+#include "include/uapi/drm/virtgpu_drm.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -37,24 +38,16 @@ extern "C" {
  * compatibility Keep fields aligned to their size
  */
 
-#define VIRTGPU_PARAM_QUERY_DEV 11 /* Query the virtio device name. */
-#define DRM_VIRTGPU_GETPARAM    0x03
 #define ARRAY_SIZE(A) (sizeof(A) / sizeof(*(A)))
 
-struct drm_virtgpu_getparam {
-  __u64 param;
-  __u64 value;
-};
+#define VIRTGPU_PARAM_RESOURCE_BLOB_BIT (1ull << VIRTGPU_PARAM_RESOURCE_BLOB)
+#define VIRTGPU_PARAM_QUERY_DEV_BIT (1ull << VIRTGPU_PARAM_QUERY_DEV)
 
 struct virtgpu_param {
   uint64_t param;
   const char *name;
   uint32_t value;
 };
-
-#define DRM_IOCTL_VIRTGPU_GETPARAM \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_VIRTGPU_GETPARAM,\
-           struct drm_virtgpu_getparam)
 
 #define PARAM(x)                                                                                   \
   (struct virtgpu_param)                                                                     \
@@ -63,7 +56,7 @@ struct virtgpu_param {
   }
 
 static struct virtgpu_param params[] = {
-  PARAM(VIRTGPU_PARAM_QUERY_DEV),
+  PARAM(VIRTGPU_PARAM_QUERY_DEV),PARAM(VIRTGPU_PARAM_RESOURCE_BLOB),
 };
 
 #if defined(__cplusplus)

--- a/hwc2_device/HwcLayer.h
+++ b/hwc2_device/HwcLayer.h
@@ -112,15 +112,15 @@ class HwcLayer {
 
   /* Layer state */
  public:
-  void PopulateLayerData(bool test);
-
+  void PopulateLayerData(bool test, bool IsPixelBlendModeSupported = true);
+  void PopulateLayerDataWithoutAddFb();
   buffer_handle_t GetBufferHandle() {return buffer_handle_;}
   bool IsLayerUsableAsDevice() const {
     return !bi_get_failed_ && !fb_import_failed_ && buffer_handle_ != nullptr;
   }
 
  private:
-  void ImportFb();
+  void ImportFb(bool IsPixelBlendModeSupported);
   bool bi_get_failed_{};
   bool fb_import_failed_{};
 


### PR DESCRIPTION
Fix display black region while running KOG

Since virtio-gpu do not support pixel blend mode,
so if layer's format is ABGR,  virtio-gpu can not
handle alpha correctly, this will cause display
black region. hwc will change ABGR to XBGR to fix.

Tracked-On: OAM-126616
