### PR TITLE
drm_hwcomposer: Add writeback connector support

### DIFF
--- a/1
+++ b/1
@@ -775,7 +775,7 @@ HWC2::Error HwcDisplay::SetOutputBuffer(buffer_handle_t buffer,
     return HWC2::Error::BadLayer;
   }
   /* TODO: Check if format is supported by writeback connector */
-  return HWC2::Error::None;
+  return HWC2::Error::None;	
 }
 
 HWC2::Error HwcDisplay::SetPowerMode(int32_t mode_in) {

--- a/drm/DrmAtomicStateManager.h
+++ b/drm/DrmAtomicStateManager.h
@@ -41,6 +41,8 @@ struct AtomicCommitArgs {
   std::optional<bool> active;
   std::shared_ptr<DrmKmsPlan> composition;
   bool color_adjustment = false;
+  std::shared_ptr<DrmFbIdHandle> writeback_fb;
+  SharedFd writeback_release_fence;
 
   /* out */
   UniqueFd out_fence;

--- a/drm/DrmConnector.h
+++ b/drm/DrmConnector.h
@@ -114,6 +114,13 @@ class DrmConnector : public PipelineBindable<DrmConnector> {
     return hdr_metadata_;
   }
 
+  auto &GetWritebackFbIdProperty() const {
+    return writeback_fb_id_;
+  }
+
+  auto &GetWritebackOutFenceProperty() const {
+    return writeback_out_fence_;
+  }
 
   auto IsConnected() const {
     return connector_->connection == DRM_MODE_CONNECTED;

--- a/drm/DrmDevice.cpp
+++ b/drm/DrmDevice.cpp
@@ -317,6 +317,11 @@ auto DrmDevice::GetConnectors()
   return connectors_;
 }
 
+auto DrmDevice::GetWritebackConnectors()
+    -> const std::vector<std::unique_ptr<DrmConnector>> & {
+  return writeback_connectors_;
+}
+
 auto DrmDevice::GetPlanes() -> const std::vector<std::unique_ptr<DrmPlane>> & {
   return planes_;
 }

--- a/drm/DrmDevice.h
+++ b/drm/DrmDevice.h
@@ -50,6 +50,7 @@ class DrmDevice {
   }
 
   auto GetConnectors() -> const std::vector<std::unique_ptr<DrmConnector>> &;
+  auto GetWritebackConnectors() -> const std::vector<std::unique_ptr<DrmConnector>> &;
   auto GetPlanes() -> const std::vector<std::unique_ptr<DrmPlane>> &;
   auto GetCrtcs() -> const std::vector<std::unique_ptr<DrmCrtc>> &;
   auto GetEncoders() -> const std::vector<std::unique_ptr<DrmEncoder>> &;
@@ -121,7 +122,7 @@ class DrmDevice {
   bool hdr_device_checked_ = false;
 
   std::vector<std::unique_ptr<DrmConnector>> connectors_;
-  std::vector<std::unique_ptr<DrmConnector>> writeback_connectors_;
+  std::vector<std::unique_ptr<DrmConnector>> rriteback_connectors_;
   std::vector<std::unique_ptr<DrmEncoder>> encoders_;
   std::vector<std::unique_ptr<DrmCrtc>> crtcs_;
   std::vector<std::unique_ptr<DrmPlane>> planes_;

--- a/drm/ResourceManager.cpp
+++ b/drm/ResourceManager.cpp
@@ -293,4 +293,30 @@ auto ResourceManager::GetOrderedConnectors() -> std::vector<DrmConnector *> {
 
   return ordered_connectors;
 }
+
+auto ResourceManager::GetVirtualDisplayPipeline()
+    -> std::shared_ptr<DrmDisplayPipeline> {
+  for (auto &drm : drms_) {
+    for (const auto &conn : drm->GetWritebackConnectors()) {
+      auto pipeline = DrmDisplayPipeline::CreatePipeline(*conn);
+      if (!pipeline) {
+        ALOGE("Failed to create pipeline for writeback connector %s",
+              conn->GetName().c_str());
+      }
+      if (pipeline) {
+        return pipeline;
+      }
+    }
+  }
+  return {};
+}
+
+auto ResourceManager::GetWritebackConnectorsCount() -> uint32_t {
+  uint32_t count = 0;
+  for (auto &drm : drms_) {
+    count += drm->GetWritebackConnectors().size();
+  }
+  return count;
+}
+
 }  // namespace android

--- a/drm/ResourceManager.h
+++ b/drm/ResourceManager.h
@@ -57,6 +57,8 @@ class ResourceManager {
     return main_lock_;
   }
 
+  auto GetVirtualDisplayPipeline() -> std::shared_ptr<DrmDisplayPipeline>;
+  auto GetWritebackConnectorsCount() -> uint32_t;
   static auto GetTimeMonotonicNs() -> int64_t;
 
  private:

--- a/hwc2_device/HwcDisplay.h
+++ b/hwc2_device/HwcDisplay.h
@@ -187,6 +187,15 @@ class HwcDisplay {
 
   void Deinit();
 
+  auto &GetWritebackLayer() {
+    return writeback_layer_;
+  }
+
+  void SetVirtualDisplayResolution(uint16_t width, uint16_t height) {
+    virtual_disp_width_ = width;
+    virtual_disp_height_ = height;
+  }
+
  private:
   enum ClientFlattenningState : int32_t {
     Disabled = -3,
@@ -227,6 +236,9 @@ class HwcDisplay {
 
   std::map<hwc2_layer_t, HwcLayer> layers_;
   HwcLayer client_layer_;
+  std::unique_ptr<HwcLayer> writeback_layer_;
+  uint16_t virtual_disp_width_{};
+  uint16_t virtual_disp_height_{};
   int32_t color_mode_{};
   std::vector<int32_t> current_color_mode_ = {HAL_COLOR_MODE_NATIVE, HAL_COLOR_MODE_BT2020, HAL_COLOR_MODE_BT2100_PQ, HAL_COLOR_MODE_BT2100_HLG, /*HAL_COLOR_MODE_DISPLAY_BT2020*/};
   std::array<float, MATRIX_SIZE> color_transform_matrix_{};


### PR DESCRIPTION
Writeback connector is a special case of connector, which can be linked to a CRTC in order to get the result of the composition back to a memory buffer.