### PR TITLE
Miscellaneous fixes of blitter

### DIFF
--- a/drm/DrmFbImporter.cpp
+++ b/drm/DrmFbImporter.cpp
@@ -49,7 +49,9 @@ auto DrmFbIdHandle::CreateInstance(BufferInfo *bo, GemHandle first_gem_handle,
   int *fds = bo->use_shadow_fds ? bo->shadow_fds : bo->prime_fds;
   local->use_shadow_buffers_ = bo->use_shadow_fds;
   if (local->use_shadow_buffers_) {
-    local->intel_fd_ = bo->blitter->GetFd();
+    local->blitter_ = bo->blitter;
+    local->shadow_fds_[0] = bo->shadow_fds[0];
+    local->shadow_handles_[0] = bo->shadow_buffer_handles[0];
   }
 
   /* Framebuffer object creation require gem handle for every used plane */
@@ -164,7 +166,7 @@ DrmFbIdHandle::~DrmFbIdHandle() {
     }
     if (use_shadow_buffers_) {
       gem_close.handle = shadow_handles_[i];
-      err = drmIoctl(intel_fd_, DRM_IOCTL_GEM_CLOSE, &gem_close);
+      err = drmIoctl(blitter_->GetFd(), DRM_IOCTL_GEM_CLOSE, &gem_close);
       if (err != 0) {
         ALOGE("Failed to close shadow handle %d, errno: %d", gem_handles_[i], errno);
       }

--- a/drm/DrmFbImporter.h
+++ b/drm/DrmFbImporter.h
@@ -60,7 +60,7 @@ class DrmFbIdHandle {
   std::array<GemHandle, kBufferMaxPlanes> shadow_handles_{};
   std::array<int, kBufferMaxPlanes> shadow_fds_{};
   bool use_shadow_buffers_;
-  int intel_fd_;
+  std::shared_ptr<IntelBlitter> blitter_;
 };
 
 class DrmFbImporter {

--- a/utils/intel_blit.cpp
+++ b/utils/intel_blit.cpp
@@ -90,10 +90,6 @@ struct i915_device {
   struct iris_memregion vram, sys;
 };
 
-static struct i915_device dev = {
-  .initialized = false,
-};
-
 static void batch_reset(struct intel_info *info) {
   info->cur = info->vaddr;
 }
@@ -175,7 +171,7 @@ static void batch_destroy(struct intel_info *info) {
   }
 }
 
-static int intel_update_meminfo(int fd) {
+static int intel_update_meminfo(int fd, struct i915_device &dev) {
   if (dev.initialized) {
     return 0;
   }
@@ -236,7 +232,8 @@ static int intel_dgpu_fd_new() {
       close(fd);
       continue;
     }
-    intel_update_meminfo(fd);
+    struct i915_device dev{};
+    intel_update_meminfo(fd, dev);
     if (dev.has_local_mem) {
       drmFreeVersion(version);
       return fd;
@@ -644,6 +641,8 @@ int intel_create_buffer(struct intel_info *info, uint32_t width, uint32_t height
   const uint32_t bpp = 4;
   uint32_t aligned_height, stride = width * bpp;
   static uint32_t alloc_count = 0;
+  struct i915_device dev{};
+  intel_update_meminfo(fd, dev);
 
   switch (modifier) {
   case DRM_FORMAT_MOD_LINEAR:


### PR DESCRIPTION
* Save first shadow buffer handle and fd for destroying.
* Make i915_device local to avoid race condition.

Tracked-On: OAM-129252