### PR TITLE
Rename DRM_FORMAT_NV12_Y_TILED_INTEL

### DIFF
--- a/drm/DrmDevice.h
+++ b/drm/DrmDevice.h
@@ -27,7 +27,7 @@
 #include "DrmFbImporter.h"
 #include "utils/UniqueFd.h"
 
-#define DRM_FORMAT_NV12_Y_TILED_INTEL fourcc_code('9', '9', '9', '6')
+#define DRM_FORMAT_NV12_INTEL fourcc_code('9', '9', '9', '6')
 namespace android {
 
 class DrmFbImporter;

--- a/drm/DrmFbImporter.cpp
+++ b/drm/DrmFbImporter.cpp
@@ -117,7 +117,7 @@ auto DrmFbIdHandle::CreateInstance(BufferInfo *bo, GemHandle first_gem_handle,
                         local->gem_handles_.data(), &bo->pitches[0],
                         &bo->offsets[0], &local->fb_id_, 0);
   } else {
-    if (bo->format == DRM_FORMAT_NV12_Y_TILED_INTEL)
+    if (bo->format == DRM_FORMAT_NV12_INTEL)
       bo->format = DRM_FORMAT_NV12;
     err = drmModeAddFB2WithModifiers(drm.GetFd(), bo->width, bo->height,
                                      bo->format, local->gem_handles_.data(),

--- a/drm/DrmPlane.cpp
+++ b/drm/DrmPlane.cpp
@@ -195,7 +195,7 @@ bool DrmPlane::IsValidForLayer(LayerData *layer) {
 
 bool DrmPlane::IsFormatSupported(uint32_t format) const {
   return std::find(std::begin(formats_), std::end(formats_), format) !=
-         std::end(formats_) || format == DRM_FORMAT_NV12_Y_TILED_INTEL;
+         std::end(formats_) || format == DRM_FORMAT_NV12_INTEL;
 }
 
 bool DrmPlane::IsResolutionSupported(hwc_rect_t display_frame) {


### PR DESCRIPTION
Replace DRM_FORMAT_NV12_Y_TILED_INTEL with a more common name DRM_FORMAT_NV12_INTEL.

Tracked-On: OAM-129537