### PR TITLE
Don't manually zero intel_info

### DIFF
--- a/utils/intel_blit.cpp
+++ b/utils/intel_blit.cpp
@@ -607,7 +607,6 @@ int intel_blit_init(struct intel_info *info) {
   static int addr_offset = 0;
   int ret;
 
-  memset(info, 0, sizeof(*info));
   ret = batch_init(info);
   if (ret < 0) {
     return ret;


### PR DESCRIPTION
As we are using C++ now, the structure will be initialized by default constructor. Manually zeroing the structure might cause it in undefined state.

Tracked-On: OAM-131913