### PR TITLE
drm_hwcomposer: support for headless mode bounds

### DIFF
--- a/hwc2_device/HwcDisplay.cpp
+++ b/hwc2_device/HwcDisplay.cpp
@@ -326,6 +326,9 @@ auto HwcDisplay::ValidateStagedComposition() -> std::vector<ChangedLayer> {
 
 auto HwcDisplay::GetDisplayBoundsMm() -> std::pair<int32_t, int32_t> {
   ATRACE_CALL();
+  if (IsInHeadlessMode()) {
+    return {configs_.mm_width, -1};
+  }
   const auto bounds = GetEdid()->GetBoundsMm();
   if (bounds.first > 0 || bounds.second > 0) {
     return bounds;
@@ -599,7 +602,7 @@ HWC2::Error HwcDisplay::GetDisplayAttribute(hwc2_config_t config,
       *value = hwc_config.mode.GetVSyncPeriodNs();
       break;
     case HWC2::Attribute::DpiY:
-      *value = GetEdid()->GetDpiY();
+      *value = IsInHeadlessMode() ? -1 : GetEdid()->GetDpiY();
       if (*value < 0) {
         // default to raw mode DpiX for both x and y when no good value
         // can be provided from edid.
@@ -610,7 +613,7 @@ HWC2::Error HwcDisplay::GetDisplayAttribute(hwc2_config_t config,
       break;
     case HWC2::Attribute::DpiX:
       // Dots per 1000 inches
-      *value = GetEdid()->GetDpiX();
+      *value = IsInHeadlessMode() ? -1 : GetEdid()->GetDpiX();
       if (*value < 0) {
         // default to raw mode DpiX for both x and y when no good value
         // can be provided from edid.


### PR DESCRIPTION
Currently there is a null pointer dereferencing due to some recent changes meant to use edid for dpi computation. This change aims at fixing this issue.

Change-Id: I58e7f3f48959d2f3de971546dcf91c93225e04c8