### PR TITLE
drm_hwcomposer: Fix deadlock with flattening

### DIFF
--- a/hwc3/ComposerClient.cpp
+++ b/hwc3/ComposerClient.cpp
@@ -730,7 +730,7 @@ void ComposerClient::ExecuteDisplayCommand(const DisplayCommand& command) {
     }
     cmd_result_writer_->AddChanges(changes);
     auto hwc3_display = DrmHwcThree::GetHwc3Display(*display);
-    hwc3_display->must_validate = false;
+    hwc_->ClearMustValidateDisplay(display_id);
     display->setExpectedPresentTime(command.expectedPresentTime);
     // TODO: DisplayRequests are not implemented.
   }
@@ -751,7 +751,7 @@ void ComposerClient::ExecuteDisplayCommand(const DisplayCommand& command) {
 
   if (command.presentDisplay || shall_present_now) {
     auto hwc3_display = DrmHwcThree::GetHwc3Display(*display);
-    if (hwc3_display->must_validate) {
+    if (hwc_->GetMustValidateDisplay(display_id)) {
       cmd_result_writer_->AddError(hwc3::Error::kNotValidated);
       return;
     }
@@ -1505,7 +1505,7 @@ ndk::ScopedAStatus ComposerClient::getDisplayConfigurations(
   const auto bounds = display->GetDisplayBoundsMm();
   for (const auto& [id, config] : configs.hwc_configs) {
     configurations->push_back(
-        HwcDisplayConfigToAidlConfiguration(/*width =*/ bounds.first, 
+        HwcDisplayConfigToAidlConfiguration(/*width =*/ bounds.first,
                                             /*height =*/ bounds.second,
                                             config));
   }

--- a/hwc3/DrmHwcThree.cpp
+++ b/hwc3/DrmHwcThree.cpp
@@ -62,14 +62,8 @@ void DrmHwcThree::SendVsyncPeriodTimingChangedEventToClient(
 
 void DrmHwcThree::SendRefreshEventToClient(uint64_t display_id) {
   {
-    const std::unique_lock lock(GetResMan().GetMainLock());
-    auto* idisplay = GetDisplay(display_id);
-    if (idisplay == nullptr) {
-      ALOGE("Failed to get display %" PRIu64, display_id);
-      return;
-    }
-    auto hwc3_display = GetHwc3Display(*idisplay);
-    hwc3_display->must_validate = true;
+    const std::scoped_lock lock(must_validate_lock_);
+    must_validate_.insert(display_id);
   }
   composer_callback_->onRefresh(static_cast<int64_t>(display_id));
 }
@@ -96,6 +90,9 @@ void DrmHwcThree::SendHotplugEventToClient(
       event = common::DisplayHotplugEvent::ERROR_INCOMPATIBLE_CABLE;
       break;
   }
+  if (event == common::DisplayHotplugEvent::DISCONNECTED) {
+    ClearMustValidateDisplay(display_id);
+  }
   composer_callback_->onHotplugEvent(static_cast<int64_t>(display_id), event);
 }
 
@@ -104,9 +101,22 @@ void DrmHwcThree::SendHotplugEventToClient(
 void DrmHwcThree::SendHotplugEventToClient(
     hwc2_display_t display_id, DrmHwc::DisplayStatus display_status) {
   bool connected = display_status != DrmHwc::kDisconnected;
+  if (!connected) {
+    ClearMustValidateDisplay(display_id);
+  }
   composer_callback_->onHotplug(static_cast<int64_t>(display_id), connected);
 }
 
 #endif
+
+auto DrmHwcThree::GetMustValidateDisplay(uint64_t display_id) -> bool {
+  std::scoped_lock lock(must_validate_lock_);
+  return must_validate_.find(display_id) != must_validate_.end();
+}
+
+void DrmHwcThree::ClearMustValidateDisplay(uint64_t display_id) {
+  std::scoped_lock lock(must_validate_lock_);
+  must_validate_.erase(display_id);
+}
 
 }  // namespace aidl::android::hardware::graphics::composer3::impl

--- a/hwc3/DrmHwcThree.h
+++ b/hwc3/DrmHwcThree.h
@@ -25,7 +25,6 @@ namespace aidl::android::hardware::graphics::composer3::impl {
 
 class Hwc3Display : public ::android::FrontendDisplayBase {
  public:
-  bool must_validate = false;
 
   int64_t next_layer_id = 1;
 };
@@ -49,7 +48,13 @@ class DrmHwcThree : public ::android::DrmHwc {
   static auto GetHwc3Display(::android::HwcDisplay& display)
       -> std::shared_ptr<Hwc3Display>;
 
+  auto GetMustValidateDisplay(uint64_t display_id) -> bool;
+  void ClearMustValidateDisplay(uint64_t display_id);
+
  private:
   std::shared_ptr<IComposerCallback> composer_callback_;
+
+  std::mutex must_validate_lock_;
+  std::set<uint64_t> must_validate_ GUARDED_BY(must_validate_lock_);
 };
 }  // namespace aidl::android::hardware::graphics::composer3::impl


### PR DESCRIPTION
FlatteningController acquires its internal lock first, and then acquires the global lock in DrmHwcThree::SendRefreshEventToClient.

During normal validate/present, the thread acquires the global lock first, and will acquire the FlatteningController internal lock in NewFrame.

Move the "must_validate" flag out of Hwc3Display to remove the need to acquire the global lock in the SendRefreshEventToClient callback. Add a std::set to track which displays must be validated, and protect access to this set with a different mutex to avoid deadlocks.

Change-Id: I62d59252107f9f16a4b8bb43f850115bf327a127