### PR TITLE
Fix crash when setting power mode in headless mode

### DIFF
--- a/hwc2_device/HwcDisplay.cpp
+++ b/hwc2_device/HwcDisplay.cpp
@@ -1024,7 +1024,8 @@ HWC2::Error HwcDisplay::SetPowerMode(int32_t mode_in) {
       break;
     case HWC2::PowerMode::On:
       a_args.active = true;
-      a_args.color_adjustment = GetPipe().device->GetColorAdjustmentEnabling();
+      a_args.color_adjustment = IsInHeadlessMode() ?
+          false : GetPipe().device->GetColorAdjustmentEnabling();
       break;
     case HWC2::PowerMode::Doze:
     case HWC2::PowerMode::DozeSuspend:


### PR DESCRIPTION
Accessing pipeline in headless mode would crash due to NULL pointer.

Tracked-On: OAM-134024